### PR TITLE
Fix shadcn examples for tsc

### DIFF
--- a/src/app/shadcn/card/page.tsx
+++ b/src/app/shadcn/card/page.tsx
@@ -1,5 +1,23 @@
-import { Card } from "@/components/ui/card";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardAction,
+  CardContent,
+  CardFooter,
+} from "@/components/ui/card";
 
 export default function CardPage() {
-  return <Card>Card</Card>;
-} 
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Title</CardTitle>
+        <CardDescription>Description</CardDescription>
+        <CardAction>Action</CardAction>
+      </CardHeader>
+      <CardContent>Content</CardContent>
+      <CardFooter>Footer</CardFooter>
+    </Card>
+  );
+}

--- a/src/app/shadcn/command/page.tsx
+++ b/src/app/shadcn/command/page.tsx
@@ -1,5 +1,32 @@
-import { Command } from "@/components/ui/command";
+import * as React from "react";
+import {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandItem,
+  CommandGroup,
+  CommandEmpty,
+  CommandSeparator,
+  CommandShortcut,
+} from "@/components/ui/command";
 
 export default function CommandPage() {
-  return <Command />;
-} 
+  return (
+    <CommandDialog open onOpenChange={() => {}}>
+      <CommandInput placeholder="Search commands..." />
+      <CommandList>
+        <CommandEmpty>No results found.</CommandEmpty>
+        <CommandGroup heading="Group">
+          <CommandItem>
+            Item <CommandShortcut>⌘1</CommandShortcut>
+          </CommandItem>
+          <CommandSeparator />
+          <CommandItem>
+            Another item <CommandShortcut>⌘2</CommandShortcut>
+          </CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/src/app/shadcn/form/page.tsx
+++ b/src/app/shadcn/form/page.tsx
@@ -1,5 +1,36 @@
-import { Form } from "@/components/ui/form";
+import { useForm } from "react-hook-form";
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
 
 export default function FormPage() {
-  return <Form>{null}</Form>;
-} 
+  const form = useForm<{ email: string }>({
+    defaultValues: { email: "" },
+  });
+
+  return (
+    <Form {...form}>
+      <form>
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Email</FormLabel>
+              <FormControl>
+                <Input placeholder="Email" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </form>
+    </Form>
+  );
+}

--- a/src/app/shadcn/input-otp/page.tsx
+++ b/src/app/shadcn/input-otp/page.tsx
@@ -1,5 +1,23 @@
-import { InputOTP } from "@/components/ui/input-otp";
+import * as React from "react";
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSlot,
+  InputOTPSeparator,
+} from "@/components/ui/input-otp";
 
 export default function InputOtpPage() {
-  return <InputOTP value="" onChange={() => {}} />;
-} 
+  const [value, setValue] = React.useState("");
+
+  return (
+    <InputOTP value={value} onChange={setValue} maxLength={4}>
+      <InputOTPGroup>
+        <InputOTPSlot index={0} />
+        <InputOTPSlot index={1} />
+        <InputOTPSeparator />
+        <InputOTPSlot index={2} />
+        <InputOTPSlot index={3} />
+      </InputOTPGroup>
+    </InputOTP>
+  );
+}


### PR DESCRIPTION
## Summary
- implement a basic form example using `useForm`
- show full usage of `InputOTP`
- expand Card example to use all exports
- expand Command example with dialog and items

## Testing
- `pnpm tsc`