### PR TITLE
Move shadcn pages to client components

### DIFF
--- a/src/app/shadcn/accordion/client.tsx
+++ b/src/app/shadcn/accordion/client.tsx
@@ -1,0 +1,14 @@
+"use client"
+
+import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from "@/components/ui/accordion";
+
+export default function AccordionPage() {
+  return (
+    <Accordion type="single" collapsible>
+      <AccordionItem value="item-1">
+        <AccordionTrigger>Accordion Item</AccordionTrigger>
+        <AccordionContent>Accordion content</AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  );
+} 

--- a/src/app/shadcn/accordion/page.tsx
+++ b/src/app/shadcn/accordion/page.tsx
@@ -1,12 +1,5 @@
-import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from "@/components/ui/accordion";
+import Client from "./client";
 
-export default function AccordionPage() {
-  return (
-    <Accordion type="single" collapsible>
-      <AccordionItem value="item-1">
-        <AccordionTrigger>Accordion Item</AccordionTrigger>
-        <AccordionContent>Accordion content</AccordionContent>
-      </AccordionItem>
-    </Accordion>
-  );
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/alert-dialog/client.tsx
+++ b/src/app/shadcn/alert-dialog/client.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import { AlertDialog, AlertDialogTrigger, AlertDialogContent } from "@/components/ui/alert-dialog";
+
+export default function AlertDialogPage() {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger>Open Alert</AlertDialogTrigger>
+      <AlertDialogContent>Alert dialog content</AlertDialogContent>
+    </AlertDialog>
+  );
+} 

--- a/src/app/shadcn/alert-dialog/page.tsx
+++ b/src/app/shadcn/alert-dialog/page.tsx
@@ -1,10 +1,5 @@
-import { AlertDialog, AlertDialogTrigger, AlertDialogContent } from "@/components/ui/alert-dialog";
+import Client from "./client";
 
-export default function AlertDialogPage() {
-  return (
-    <AlertDialog>
-      <AlertDialogTrigger>Open Alert</AlertDialogTrigger>
-      <AlertDialogContent>Alert dialog content</AlertDialogContent>
-    </AlertDialog>
-  );
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/alert/client.tsx
+++ b/src/app/shadcn/alert/client.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
+
+export default function AlertPage() {
+  return (
+    <Alert>
+      <AlertTitle>Alert title</AlertTitle>
+      <AlertDescription>Alert description</AlertDescription>
+    </Alert>
+  );
+} 

--- a/src/app/shadcn/alert/page.tsx
+++ b/src/app/shadcn/alert/page.tsx
@@ -1,10 +1,5 @@
-import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
+import Client from "./client";
 
-export default function AlertPage() {
-  return (
-    <Alert>
-      <AlertTitle>Alert title</AlertTitle>
-      <AlertDescription>Alert description</AlertDescription>
-    </Alert>
-  );
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/aspect-ratio/client.tsx
+++ b/src/app/shadcn/aspect-ratio/client.tsx
@@ -1,0 +1,11 @@
+"use client"
+
+import { AspectRatio } from "@/components/ui/aspect-ratio";
+
+export default function AspectRatioPage() {
+  return (
+    <AspectRatio ratio={16 / 9}>
+      <div style={{ background: '#eee', width: '100%', height: '100%' }}>AspectRatio</div>
+    </AspectRatio>
+  );
+} 

--- a/src/app/shadcn/aspect-ratio/page.tsx
+++ b/src/app/shadcn/aspect-ratio/page.tsx
@@ -1,9 +1,5 @@
-import { AspectRatio } from "@/components/ui/aspect-ratio";
+import Client from "./client";
 
-export default function AspectRatioPage() {
-  return (
-    <AspectRatio ratio={16 / 9}>
-      <div style={{ background: '#eee', width: '100%', height: '100%' }}>AspectRatio</div>
-    </AspectRatio>
-  );
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/avatar/client.tsx
+++ b/src/app/shadcn/avatar/client.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+
+export default function AvatarPage() {
+  return (
+    <Avatar>
+      <AvatarImage src="https://github.com/shadcn.png" alt="avatar" />
+      <AvatarFallback>CN</AvatarFallback>
+    </Avatar>
+  );
+} 

--- a/src/app/shadcn/avatar/page.tsx
+++ b/src/app/shadcn/avatar/page.tsx
@@ -1,10 +1,5 @@
-import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+import Client from "./client";
 
-export default function AvatarPage() {
-  return (
-    <Avatar>
-      <AvatarImage src="https://github.com/shadcn.png" alt="avatar" />
-      <AvatarFallback>CN</AvatarFallback>
-    </Avatar>
-  );
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/badge/client.tsx
+++ b/src/app/shadcn/badge/client.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { Badge } from "@/components/ui/badge";
+
+export default function BadgePage() {
+  return <Badge>Badge</Badge>;
+} 

--- a/src/app/shadcn/badge/page.tsx
+++ b/src/app/shadcn/badge/page.tsx
@@ -1,5 +1,5 @@
-import { Badge } from "@/components/ui/badge";
+import Client from "./client";
 
-export default function BadgePage() {
-  return <Badge>Badge</Badge>;
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/breadcrumb/client.tsx
+++ b/src/app/shadcn/breadcrumb/client.tsx
@@ -1,0 +1,15 @@
+"use client"
+
+import { Breadcrumb, BreadcrumbList, BreadcrumbItem, BreadcrumbLink } from "@/components/ui/breadcrumb";
+
+export default function BreadcrumbPage() {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+} 

--- a/src/app/shadcn/breadcrumb/page.tsx
+++ b/src/app/shadcn/breadcrumb/page.tsx
@@ -1,13 +1,5 @@
-import { Breadcrumb, BreadcrumbList, BreadcrumbItem, BreadcrumbLink } from "@/components/ui/breadcrumb";
+import Client from "./client";
 
-export default function BreadcrumbPage() {
-  return (
-    <Breadcrumb>
-      <BreadcrumbList>
-        <BreadcrumbItem>
-          <BreadcrumbLink href="#">Home</BreadcrumbLink>
-        </BreadcrumbItem>
-      </BreadcrumbList>
-    </Breadcrumb>
-  );
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/button/client.tsx
+++ b/src/app/shadcn/button/client.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { Button } from "@/components/ui/button";
+
+export default function ButtonPage() {
+  return <Button>Button</Button>;
+} 

--- a/src/app/shadcn/button/page.tsx
+++ b/src/app/shadcn/button/page.tsx
@@ -1,5 +1,5 @@
-import { Button } from "@/components/ui/button";
+import Client from "./client";
 
-export default function ButtonPage() {
-  return <Button>Button</Button>;
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/calendar/client.tsx
+++ b/src/app/shadcn/calendar/client.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { Calendar } from "@/components/ui/calendar";
+
+export default function CalendarPage() {
+  return <Calendar />;
+} 

--- a/src/app/shadcn/calendar/page.tsx
+++ b/src/app/shadcn/calendar/page.tsx
@@ -1,5 +1,5 @@
-import { Calendar } from "@/components/ui/calendar";
+import Client from "./client";
 
-export default function CalendarPage() {
-  return <Calendar />;
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/card/client.tsx
+++ b/src/app/shadcn/card/client.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardAction,
+  CardContent,
+  CardFooter,
+} from "@/components/ui/card";
+
+export default function CardPage() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Title</CardTitle>
+        <CardDescription>Description</CardDescription>
+        <CardAction>Action</CardAction>
+      </CardHeader>
+      <CardContent>Content</CardContent>
+      <CardFooter>Footer</CardFooter>
+    </Card>
+  );
+}

--- a/src/app/shadcn/card/page.tsx
+++ b/src/app/shadcn/card/page.tsx
@@ -1,23 +1,5 @@
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-  CardAction,
-  CardContent,
-  CardFooter,
-} from "@/components/ui/card";
+import Client from "./client";
 
-export default function CardPage() {
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Title</CardTitle>
-        <CardDescription>Description</CardDescription>
-        <CardAction>Action</CardAction>
-      </CardHeader>
-      <CardContent>Content</CardContent>
-      <CardFooter>Footer</CardFooter>
-    </Card>
-  );
+export default function Page() {
+  return <Client />;
 }

--- a/src/app/shadcn/carousel/client.tsx
+++ b/src/app/shadcn/carousel/client.tsx
@@ -1,0 +1,14 @@
+"use client"
+
+import { Carousel, CarouselContent, CarouselItem } from "@/components/ui/carousel";
+
+export default function CarouselPage() {
+  return (
+    <Carousel>
+      <CarouselContent>
+        <CarouselItem>Item 1</CarouselItem>
+        <CarouselItem>Item 2</CarouselItem>
+      </CarouselContent>
+    </Carousel>
+  );
+} 

--- a/src/app/shadcn/carousel/page.tsx
+++ b/src/app/shadcn/carousel/page.tsx
@@ -1,12 +1,5 @@
-import { Carousel, CarouselContent, CarouselItem } from "@/components/ui/carousel";
+import Client from "./client";
 
-export default function CarouselPage() {
-  return (
-    <Carousel>
-      <CarouselContent>
-        <CarouselItem>Item 1</CarouselItem>
-        <CarouselItem>Item 2</CarouselItem>
-      </CarouselContent>
-    </Carousel>
-  );
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/chart/page.tsx
+++ b/src/app/shadcn/chart/page.tsx
@@ -1,3 +1,5 @@
-import { ChartPage } from "./client"
+import { ChartPage as Client } from "./client";
 
-export default ChartPage
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/checkbox/client.tsx
+++ b/src/app/shadcn/checkbox/client.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { Checkbox } from "@/components/ui/checkbox";
+
+export default function CheckboxPage() {
+  return <Checkbox />;
+} 

--- a/src/app/shadcn/checkbox/page.tsx
+++ b/src/app/shadcn/checkbox/page.tsx
@@ -1,5 +1,5 @@
-import { Checkbox } from "@/components/ui/checkbox";
+import Client from "./client";
 
-export default function CheckboxPage() {
-  return <Checkbox />;
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/collapsible/client.tsx
+++ b/src/app/shadcn/collapsible/client.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
+
+export default function CollapsiblePage() {
+  return (
+    <Collapsible>
+      <CollapsibleTrigger>Toggle</CollapsibleTrigger>
+      <CollapsibleContent>Content</CollapsibleContent>
+    </Collapsible>
+  );
+} 

--- a/src/app/shadcn/collapsible/page.tsx
+++ b/src/app/shadcn/collapsible/page.tsx
@@ -1,10 +1,5 @@
-import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
+import Client from "./client";
 
-export default function CollapsiblePage() {
-  return (
-    <Collapsible>
-      <CollapsibleTrigger>Toggle</CollapsibleTrigger>
-      <CollapsibleContent>Content</CollapsibleContent>
-    </Collapsible>
-  );
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/command/page.tsx
+++ b/src/app/shadcn/command/page.tsx
@@ -1,3 +1,5 @@
-import { CommandPage } from "./client"
+import { CommandPage as Client } from "./client";
 
-export default CommandPage
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/context-menu/client.tsx
+++ b/src/app/shadcn/context-menu/client.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import { ContextMenu, ContextMenuTrigger, ContextMenuContent } from "@/components/ui/context-menu";
+
+export default function ContextMenuPage() {
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger>Right click me</ContextMenuTrigger>
+      <ContextMenuContent>Menu content</ContextMenuContent>
+    </ContextMenu>
+  );
+} 

--- a/src/app/shadcn/context-menu/page.tsx
+++ b/src/app/shadcn/context-menu/page.tsx
@@ -1,10 +1,5 @@
-import { ContextMenu, ContextMenuTrigger, ContextMenuContent } from "@/components/ui/context-menu";
+import Client from "./client";
 
-export default function ContextMenuPage() {
-  return (
-    <ContextMenu>
-      <ContextMenuTrigger>Right click me</ContextMenuTrigger>
-      <ContextMenuContent>Menu content</ContextMenuContent>
-    </ContextMenu>
-  );
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/dialog/client.tsx
+++ b/src/app/shadcn/dialog/client.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import { Dialog, DialogTrigger, DialogContent } from "@/components/ui/dialog";
+
+export default function DialogPage() {
+  return (
+    <Dialog>
+      <DialogTrigger>Open Dialog</DialogTrigger>
+      <DialogContent>Dialog content</DialogContent>
+    </Dialog>
+  );
+} 

--- a/src/app/shadcn/dialog/page.tsx
+++ b/src/app/shadcn/dialog/page.tsx
@@ -1,10 +1,5 @@
-import { Dialog, DialogTrigger, DialogContent } from "@/components/ui/dialog";
+import Client from "./client";
 
-export default function DialogPage() {
-  return (
-    <Dialog>
-      <DialogTrigger>Open Dialog</DialogTrigger>
-      <DialogContent>Dialog content</DialogContent>
-    </Dialog>
-  );
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/drawer/client.tsx
+++ b/src/app/shadcn/drawer/client.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import { Drawer, DrawerTrigger, DrawerContent } from "@/components/ui/drawer";
+
+export default function DrawerPage() {
+  return (
+    <Drawer>
+      <DrawerTrigger>Open Drawer</DrawerTrigger>
+      <DrawerContent>Drawer content</DrawerContent>
+    </Drawer>
+  );
+} 

--- a/src/app/shadcn/drawer/page.tsx
+++ b/src/app/shadcn/drawer/page.tsx
@@ -1,10 +1,5 @@
-import { Drawer, DrawerTrigger, DrawerContent } from "@/components/ui/drawer";
+import Client from "./client";
 
-export default function DrawerPage() {
-  return (
-    <Drawer>
-      <DrawerTrigger>Open Drawer</DrawerTrigger>
-      <DrawerContent>Drawer content</DrawerContent>
-    </Drawer>
-  );
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/dropdown-menu/client.tsx
+++ b/src/app/shadcn/dropdown-menu/client.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent } from "@/components/ui/dropdown-menu";
+
+export default function DropdownMenuPage() {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger>Open Menu</DropdownMenuTrigger>
+      <DropdownMenuContent>Menu content</DropdownMenuContent>
+    </DropdownMenu>
+  );
+} 

--- a/src/app/shadcn/dropdown-menu/page.tsx
+++ b/src/app/shadcn/dropdown-menu/page.tsx
@@ -1,10 +1,5 @@
-import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent } from "@/components/ui/dropdown-menu";
+import Client from "./client";
 
-export default function DropdownMenuPage() {
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger>Open Menu</DropdownMenuTrigger>
-      <DropdownMenuContent>Menu content</DropdownMenuContent>
-    </DropdownMenu>
-  );
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/form/page.tsx
+++ b/src/app/shadcn/form/page.tsx
@@ -1,8 +1,5 @@
-import ClientForm from "./client";
+import Client from "./client";
 
-export default function FormPage() {
-  
-  return (
-    <ClientForm />
-  );
+export default function Page() {
+  return <Client />;
 }

--- a/src/app/shadcn/hover-card/client.tsx
+++ b/src/app/shadcn/hover-card/client.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import { HoverCard, HoverCardTrigger, HoverCardContent } from "@/components/ui/hover-card";
+
+export default function HoverCardPage() {
+  return (
+    <HoverCard>
+      <HoverCardTrigger>Hover me</HoverCardTrigger>
+      <HoverCardContent>Hover card content</HoverCardContent>
+    </HoverCard>
+  );
+} 

--- a/src/app/shadcn/hover-card/page.tsx
+++ b/src/app/shadcn/hover-card/page.tsx
@@ -1,10 +1,5 @@
-import { HoverCard, HoverCardTrigger, HoverCardContent } from "@/components/ui/hover-card";
+import Client from "./client";
 
-export default function HoverCardPage() {
-  return (
-    <HoverCard>
-      <HoverCardTrigger>Hover me</HoverCardTrigger>
-      <HoverCardContent>Hover card content</HoverCardContent>
-    </HoverCard>
-  );
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/input-otp/page.tsx
+++ b/src/app/shadcn/input-otp/page.tsx
@@ -1,3 +1,5 @@
-import { InputOtpPage } from "./client"
+import { InputOtpPage as Client } from "./client";
 
-export default InputOtpPage
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/input/client.tsx
+++ b/src/app/shadcn/input/client.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { Input } from "@/components/ui/input";
+
+export default function InputPage() {
+  return <Input placeholder="Input" />;
+} 

--- a/src/app/shadcn/input/page.tsx
+++ b/src/app/shadcn/input/page.tsx
@@ -1,5 +1,5 @@
-import { Input } from "@/components/ui/input";
+import Client from "./client";
 
-export default function InputPage() {
-  return <Input placeholder="Input" />;
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/label/client.tsx
+++ b/src/app/shadcn/label/client.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { Label } from "@/components/ui/label";
+
+export default function LabelPage() {
+  return <Label>Label</Label>;
+} 

--- a/src/app/shadcn/label/page.tsx
+++ b/src/app/shadcn/label/page.tsx
@@ -1,5 +1,5 @@
-import { Label } from "@/components/ui/label";
+import Client from "./client";
 
-export default function LabelPage() {
-  return <Label>Label</Label>;
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/menubar/client.tsx
+++ b/src/app/shadcn/menubar/client.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { Menubar } from "@/components/ui/menubar";
+
+export default function MenubarPage() {
+  return <Menubar />;
+} 

--- a/src/app/shadcn/menubar/page.tsx
+++ b/src/app/shadcn/menubar/page.tsx
@@ -1,5 +1,5 @@
-import { Menubar } from "@/components/ui/menubar";
+import Client from "./client";
 
-export default function MenubarPage() {
-  return <Menubar />;
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/navigation-menu/client.tsx
+++ b/src/app/shadcn/navigation-menu/client.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { NavigationMenu } from "@/components/ui/navigation-menu";
+
+export default function NavigationMenuPage() {
+  return <NavigationMenu />;
+} 

--- a/src/app/shadcn/navigation-menu/page.tsx
+++ b/src/app/shadcn/navigation-menu/page.tsx
@@ -1,5 +1,5 @@
-import { NavigationMenu } from "@/components/ui/navigation-menu";
+import Client from "./client";
 
-export default function NavigationMenuPage() {
-  return <NavigationMenu />;
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/pagination/client.tsx
+++ b/src/app/shadcn/pagination/client.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { Pagination } from "@/components/ui/pagination";
+
+export default function PaginationPage() {
+  return <Pagination />;
+} 

--- a/src/app/shadcn/pagination/page.tsx
+++ b/src/app/shadcn/pagination/page.tsx
@@ -1,5 +1,5 @@
-import { Pagination } from "@/components/ui/pagination";
+import Client from "./client";
 
-export default function PaginationPage() {
-  return <Pagination />;
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/popover/client.tsx
+++ b/src/app/shadcn/popover/client.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+
+export default function PopoverPage() {
+  return (
+    <Popover>
+      <PopoverTrigger>Open Popover</PopoverTrigger>
+      <PopoverContent>Popover content</PopoverContent>
+    </Popover>
+  );
+} 

--- a/src/app/shadcn/popover/page.tsx
+++ b/src/app/shadcn/popover/page.tsx
@@ -1,10 +1,5 @@
-import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import Client from "./client";
 
-export default function PopoverPage() {
-  return (
-    <Popover>
-      <PopoverTrigger>Open Popover</PopoverTrigger>
-      <PopoverContent>Popover content</PopoverContent>
-    </Popover>
-  );
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/progress/client.tsx
+++ b/src/app/shadcn/progress/client.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { Progress } from "@/components/ui/progress";
+
+export default function ProgressPage() {
+  return <Progress value={50} />;
+} 

--- a/src/app/shadcn/progress/page.tsx
+++ b/src/app/shadcn/progress/page.tsx
@@ -1,5 +1,5 @@
-import { Progress } from "@/components/ui/progress";
+import Client from "./client";
 
-export default function ProgressPage() {
-  return <Progress value={50} />;
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/radio-group/client.tsx
+++ b/src/app/shadcn/radio-group/client.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+
+export default function RadioGroupPage() {
+  return (
+    <RadioGroup>
+      <RadioGroupItem value="1" />
+      <RadioGroupItem value="2" />
+    </RadioGroup>
+  );
+} 

--- a/src/app/shadcn/radio-group/page.tsx
+++ b/src/app/shadcn/radio-group/page.tsx
@@ -1,10 +1,5 @@
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import Client from "./client";
 
-export default function RadioGroupPage() {
-  return (
-    <RadioGroup>
-      <RadioGroupItem value="1" />
-      <RadioGroupItem value="2" />
-    </RadioGroup>
-  );
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/resizable/client.tsx
+++ b/src/app/shadcn/resizable/client.tsx
@@ -1,0 +1,13 @@
+"use client"
+
+import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
+
+export default function ResizablePage() {
+  return (
+    <ResizablePanelGroup direction="horizontal">
+      <ResizablePanel>Panel 1</ResizablePanel>
+      <ResizableHandle />
+      <ResizablePanel>Panel 2</ResizablePanel>
+    </ResizablePanelGroup>
+  );
+} 

--- a/src/app/shadcn/resizable/page.tsx
+++ b/src/app/shadcn/resizable/page.tsx
@@ -1,11 +1,5 @@
-import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
+import Client from "./client";
 
-export default function ResizablePage() {
-  return (
-    <ResizablePanelGroup direction="horizontal">
-      <ResizablePanel>Panel 1</ResizablePanel>
-      <ResizableHandle />
-      <ResizablePanel>Panel 2</ResizablePanel>
-    </ResizablePanelGroup>
-  );
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/scroll-area/client.tsx
+++ b/src/app/shadcn/scroll-area/client.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { ScrollArea } from "@/components/ui/scroll-area";
+
+export default function ScrollAreaPage() {
+  return <ScrollArea style={{ height: 100 }}>Scroll content</ScrollArea>;
+} 

--- a/src/app/shadcn/scroll-area/page.tsx
+++ b/src/app/shadcn/scroll-area/page.tsx
@@ -1,5 +1,5 @@
-import { ScrollArea } from "@/components/ui/scroll-area";
+import Client from "./client";
 
-export default function ScrollAreaPage() {
-  return <ScrollArea style={{ height: 100 }}>Scroll content</ScrollArea>;
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/select/client.tsx
+++ b/src/app/shadcn/select/client.tsx
@@ -1,0 +1,21 @@
+"use client"
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+} from "@/components/ui/select";
+
+export default function SelectPage() {
+  return (
+    <Select>
+      <SelectTrigger>Select a fruit</SelectTrigger>
+      <SelectContent>
+        <SelectItem value="apple">Apple</SelectItem>
+        <SelectItem value="banana">Banana</SelectItem>
+        <SelectItem value="orange">Orange</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/app/shadcn/select/page.tsx
+++ b/src/app/shadcn/select/page.tsx
@@ -1,19 +1,5 @@
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-} from "@/components/ui/select";
+import Client from "./client";
 
-export default function SelectPage() {
-  return (
-    <Select>
-      <SelectTrigger>Select a fruit</SelectTrigger>
-      <SelectContent>
-        <SelectItem value="apple">Apple</SelectItem>
-        <SelectItem value="banana">Banana</SelectItem>
-        <SelectItem value="orange">Orange</SelectItem>
-      </SelectContent>
-    </Select>
-  );
+export default function Page() {
+  return <Client />;
 }

--- a/src/app/shadcn/separator/client.tsx
+++ b/src/app/shadcn/separator/client.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { Separator } from "@/components/ui/separator";
+
+export default function SeparatorPage() {
+  return <Separator />;
+} 

--- a/src/app/shadcn/separator/page.tsx
+++ b/src/app/shadcn/separator/page.tsx
@@ -1,5 +1,5 @@
-import { Separator } from "@/components/ui/separator";
+import Client from "./client";
 
-export default function SeparatorPage() {
-  return <Separator />;
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/sheet/client.tsx
+++ b/src/app/shadcn/sheet/client.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import { Sheet, SheetTrigger, SheetContent } from "@/components/ui/sheet";
+
+export default function SheetPage() {
+  return (
+    <Sheet>
+      <SheetTrigger>Open Sheet</SheetTrigger>
+      <SheetContent>Sheet content</SheetContent>
+    </Sheet>
+  );
+} 

--- a/src/app/shadcn/sheet/page.tsx
+++ b/src/app/shadcn/sheet/page.tsx
@@ -1,10 +1,5 @@
-import { Sheet, SheetTrigger, SheetContent } from "@/components/ui/sheet";
+import Client from "./client";
 
-export default function SheetPage() {
-  return (
-    <Sheet>
-      <SheetTrigger>Open Sheet</SheetTrigger>
-      <SheetContent>Sheet content</SheetContent>
-    </Sheet>
-  );
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/sidebar/client.tsx
+++ b/src/app/shadcn/sidebar/client.tsx
@@ -1,0 +1,11 @@
+"use client"
+
+import { SidebarProvider, Sidebar } from "@/components/ui/sidebar";
+
+export default function SidebarPage() {
+  return (
+    <SidebarProvider>
+      <Sidebar />
+    </SidebarProvider>
+  );
+} 

--- a/src/app/shadcn/sidebar/page.tsx
+++ b/src/app/shadcn/sidebar/page.tsx
@@ -1,9 +1,5 @@
-import { SidebarProvider, Sidebar } from "@/components/ui/sidebar";
+import Client from "./client";
 
-export default function SidebarPage() {
-  return (
-    <SidebarProvider>
-      <Sidebar />
-    </SidebarProvider>
-  );
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/skeleton/client.tsx
+++ b/src/app/shadcn/skeleton/client.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function SkeletonPage() {
+  return <Skeleton style={{ width: 100, height: 20 }} />;
+} 

--- a/src/app/shadcn/skeleton/page.tsx
+++ b/src/app/shadcn/skeleton/page.tsx
@@ -1,5 +1,5 @@
-import { Skeleton } from "@/components/ui/skeleton";
+import Client from "./client";
 
-export default function SkeletonPage() {
-  return <Skeleton style={{ width: 100, height: 20 }} />;
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/slider/client.tsx
+++ b/src/app/shadcn/slider/client.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { Slider } from "@/components/ui/slider";
+
+export default function SliderPage() {
+  return <Slider />;
+} 

--- a/src/app/shadcn/slider/page.tsx
+++ b/src/app/shadcn/slider/page.tsx
@@ -1,5 +1,5 @@
-import { Slider } from "@/components/ui/slider";
+import Client from "./client";
 
-export default function SliderPage() {
-  return <Slider />;
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/sonner/client.tsx
+++ b/src/app/shadcn/sonner/client.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { Toaster } from "@/components/ui/sonner";
+
+export default function SonnerPage() {
+  return <Toaster />;
+} 

--- a/src/app/shadcn/sonner/page.tsx
+++ b/src/app/shadcn/sonner/page.tsx
@@ -1,5 +1,5 @@
-import { Toaster } from "@/components/ui/sonner";
+import Client from "./client";
 
-export default function SonnerPage() {
-  return <Toaster />;
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/switch/client.tsx
+++ b/src/app/shadcn/switch/client.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { Switch } from "@/components/ui/switch";
+
+export default function SwitchPage() {
+  return <Switch />;
+} 

--- a/src/app/shadcn/switch/page.tsx
+++ b/src/app/shadcn/switch/page.tsx
@@ -1,5 +1,5 @@
-import { Switch } from "@/components/ui/switch";
+import Client from "./client";
 
-export default function SwitchPage() {
-  return <Switch />;
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/table/client.tsx
+++ b/src/app/shadcn/table/client.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table";
+
+export default function TablePage() {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Header</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        <TableRow>
+          <TableCell>Cell</TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  );
+} 

--- a/src/app/shadcn/table/page.tsx
+++ b/src/app/shadcn/table/page.tsx
@@ -1,18 +1,5 @@
-import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table";
+import Client from "./client";
 
-export default function TablePage() {
-  return (
-    <Table>
-      <TableHeader>
-        <TableRow>
-          <TableHead>Header</TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        <TableRow>
-          <TableCell>Cell</TableCell>
-        </TableRow>
-      </TableBody>
-    </Table>
-  );
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/tabs/client.tsx
+++ b/src/app/shadcn/tabs/client.tsx
@@ -1,0 +1,16 @@
+"use client"
+
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+
+export default function TabsPage() {
+  return (
+    <Tabs defaultValue="tab1">
+      <TabsList>
+        <TabsTrigger value="tab1">Tab 1</TabsTrigger>
+        <TabsTrigger value="tab2">Tab 2</TabsTrigger>
+      </TabsList>
+      <TabsContent value="tab1">Tab 1 content</TabsContent>
+      <TabsContent value="tab2">Tab 2 content</TabsContent>
+    </Tabs>
+  );
+} 

--- a/src/app/shadcn/tabs/page.tsx
+++ b/src/app/shadcn/tabs/page.tsx
@@ -1,14 +1,5 @@
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import Client from "./client";
 
-export default function TabsPage() {
-  return (
-    <Tabs defaultValue="tab1">
-      <TabsList>
-        <TabsTrigger value="tab1">Tab 1</TabsTrigger>
-        <TabsTrigger value="tab2">Tab 2</TabsTrigger>
-      </TabsList>
-      <TabsContent value="tab1">Tab 1 content</TabsContent>
-      <TabsContent value="tab2">Tab 2 content</TabsContent>
-    </Tabs>
-  );
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/textarea/client.tsx
+++ b/src/app/shadcn/textarea/client.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { Textarea } from "@/components/ui/textarea";
+
+export default function TextareaPage() {
+  return <Textarea placeholder="Textarea" />;
+} 

--- a/src/app/shadcn/textarea/page.tsx
+++ b/src/app/shadcn/textarea/page.tsx
@@ -1,5 +1,5 @@
-import { Textarea } from "@/components/ui/textarea";
+import Client from "./client";
 
-export default function TextareaPage() {
-  return <Textarea placeholder="Textarea" />;
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/toggle-group/client.tsx
+++ b/src/app/shadcn/toggle-group/client.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+
+export default function ToggleGroupPage() {
+  return (
+    <ToggleGroup type="single">
+      <ToggleGroupItem value="1">Item 1</ToggleGroupItem>
+      <ToggleGroupItem value="2">Item 2</ToggleGroupItem>
+    </ToggleGroup>
+  );
+} 

--- a/src/app/shadcn/toggle-group/page.tsx
+++ b/src/app/shadcn/toggle-group/page.tsx
@@ -1,10 +1,5 @@
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import Client from "./client";
 
-export default function ToggleGroupPage() {
-  return (
-    <ToggleGroup type="single">
-      <ToggleGroupItem value="1">Item 1</ToggleGroupItem>
-      <ToggleGroupItem value="2">Item 2</ToggleGroupItem>
-    </ToggleGroup>
-  );
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/toggle/client.tsx
+++ b/src/app/shadcn/toggle/client.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { Toggle } from "@/components/ui/toggle";
+
+export default function TogglePage() {
+  return <Toggle>Toggle</Toggle>;
+} 

--- a/src/app/shadcn/toggle/page.tsx
+++ b/src/app/shadcn/toggle/page.tsx
@@ -1,5 +1,5 @@
-import { Toggle } from "@/components/ui/toggle";
+import Client from "./client";
 
-export default function TogglePage() {
-  return <Toggle>Toggle</Toggle>;
-} 
+export default function Page() {
+  return <Client />;
+}

--- a/src/app/shadcn/tooltip/client.tsx
+++ b/src/app/shadcn/tooltip/client.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+
+export default function TooltipPage() {
+  return (
+    <Tooltip>
+      <TooltipTrigger>Hover me</TooltipTrigger>
+      <TooltipContent>Tooltip content</TooltipContent>
+    </Tooltip>
+  );
+} 

--- a/src/app/shadcn/tooltip/page.tsx
+++ b/src/app/shadcn/tooltip/page.tsx
@@ -1,10 +1,5 @@
-import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+import Client from "./client";
 
-export default function TooltipPage() {
-  return (
-    <Tooltip>
-      <TooltipTrigger>Hover me</TooltipTrigger>
-      <TooltipContent>Tooltip content</TooltipContent>
-    </Tooltip>
-  );
-} 
+export default function Page() {
+  return <Client />;
+}


### PR DESCRIPTION
## Summary
- move demo pages in `app/shadcn/*` to `client.tsx`
- keep each `page.tsx` as a small wrapper for the client file

## Testing
- `pnpm lint`
