### PR TITLE
Use data files for build stats in dev mode

### DIFF
--- a/src/lib/get-build-stats.ts
+++ b/src/lib/get-build-stats.ts
@@ -46,7 +46,10 @@ export async function getBuildStats({
   routePattern,
   skipLayouts = true,
 }: BuildStatsOptions = {}): Promise<RouteStats[]> {
-  const buildDir = path.join(process.cwd(), ".next");
+  const buildDir =
+    process.env.NODE_ENV === "production"
+      ? path.join(process.cwd(), ".next")
+      : path.join(process.cwd(), "src/data");
   const buildManifestPath = path.join(buildDir, "app-build-manifest.json");
   const pathManifestPath = path.join(buildDir, "app-path-routes-manifest.json");
 


### PR DESCRIPTION
## Summary
- switch `getBuildStats` to use `.next` build data in production
- fallback to `src/data` when `NODE_ENV` is not production

## Testing
- `pnpm lint`
