### PR TITLE
Remove default exports from components

### DIFF
--- a/src/app/bundles/ui/shadcn/accordion/client.tsx
+++ b/src/app/bundles/ui/shadcn/accordion/client.tsx
@@ -2,7 +2,7 @@
 
 import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from "@/components/ui/accordion";
 
-export default function AccordionPage() {
+export function AccordionPage() {
   return (
     <Accordion type="single" collapsible>
       <AccordionItem value="item-1">

--- a/src/app/bundles/ui/shadcn/accordion/page.tsx
+++ b/src/app/bundles/ui/shadcn/accordion/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { AccordionPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <AccordionPage />;
 }

--- a/src/app/bundles/ui/shadcn/alert-dialog/client.tsx
+++ b/src/app/bundles/ui/shadcn/alert-dialog/client.tsx
@@ -2,7 +2,7 @@
 
 import { AlertDialog, AlertDialogTrigger, AlertDialogContent } from "@/components/ui/alert-dialog";
 
-export default function AlertDialogPage() {
+export function AlertDialogPage() {
   return (
     <AlertDialog>
       <AlertDialogTrigger>Open Alert</AlertDialogTrigger>

--- a/src/app/bundles/ui/shadcn/alert-dialog/page.tsx
+++ b/src/app/bundles/ui/shadcn/alert-dialog/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { AlertDialogPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <AlertDialogPage />;
 }

--- a/src/app/bundles/ui/shadcn/alert/client.tsx
+++ b/src/app/bundles/ui/shadcn/alert/client.tsx
@@ -2,7 +2,7 @@
 
 import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
 
-export default function AlertPage() {
+export function AlertPage() {
   return (
     <Alert>
       <AlertTitle>Alert title</AlertTitle>

--- a/src/app/bundles/ui/shadcn/alert/page.tsx
+++ b/src/app/bundles/ui/shadcn/alert/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { AlertPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <AlertPage />;
 }

--- a/src/app/bundles/ui/shadcn/aspect-ratio/client.tsx
+++ b/src/app/bundles/ui/shadcn/aspect-ratio/client.tsx
@@ -2,7 +2,7 @@
 
 import { AspectRatio } from "@/components/ui/aspect-ratio";
 
-export default function AspectRatioPage() {
+export function AspectRatioPage() {
   return (
     <AspectRatio ratio={16 / 9}>
       <div style={{ background: '#eee', width: '100%', height: '100%' }}>AspectRatio</div>

--- a/src/app/bundles/ui/shadcn/aspect-ratio/page.tsx
+++ b/src/app/bundles/ui/shadcn/aspect-ratio/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { AspectRatioPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <AspectRatioPage />;
 }

--- a/src/app/bundles/ui/shadcn/avatar/client.tsx
+++ b/src/app/bundles/ui/shadcn/avatar/client.tsx
@@ -2,7 +2,7 @@
 
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 
-export default function AvatarPage() {
+export function AvatarPage() {
   return (
     <Avatar>
       <AvatarImage src="https://github.com/shadcn.png" alt="avatar" />

--- a/src/app/bundles/ui/shadcn/avatar/page.tsx
+++ b/src/app/bundles/ui/shadcn/avatar/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { AvatarPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <AvatarPage />;
 }

--- a/src/app/bundles/ui/shadcn/badge/client.tsx
+++ b/src/app/bundles/ui/shadcn/badge/client.tsx
@@ -2,6 +2,6 @@
 
 import { Badge } from "@/components/ui/badge";
 
-export default function BadgePage() {
+export function BadgePage() {
   return <Badge>Badge</Badge>;
 } 

--- a/src/app/bundles/ui/shadcn/badge/page.tsx
+++ b/src/app/bundles/ui/shadcn/badge/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { BadgePage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <BadgePage />;
 }

--- a/src/app/bundles/ui/shadcn/breadcrumb/client.tsx
+++ b/src/app/bundles/ui/shadcn/breadcrumb/client.tsx
@@ -2,7 +2,7 @@
 
 import { Breadcrumb, BreadcrumbList, BreadcrumbItem, BreadcrumbLink } from "@/components/ui/breadcrumb";
 
-export default function BreadcrumbPage() {
+export function BreadcrumbPage() {
   return (
     <Breadcrumb>
       <BreadcrumbList>

--- a/src/app/bundles/ui/shadcn/breadcrumb/page.tsx
+++ b/src/app/bundles/ui/shadcn/breadcrumb/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { BreadcrumbPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <BreadcrumbPage />;
 }

--- a/src/app/bundles/ui/shadcn/button/client.tsx
+++ b/src/app/bundles/ui/shadcn/button/client.tsx
@@ -2,6 +2,6 @@
 
 import { Button } from "@/components/ui/button";
 
-export default function ButtonPage() {
+export function ButtonPage() {
   return <Button>Button</Button>;
 } 

--- a/src/app/bundles/ui/shadcn/button/page.tsx
+++ b/src/app/bundles/ui/shadcn/button/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { ButtonPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <ButtonPage />;
 }

--- a/src/app/bundles/ui/shadcn/calendar/client.tsx
+++ b/src/app/bundles/ui/shadcn/calendar/client.tsx
@@ -2,6 +2,6 @@
 
 import { Calendar } from "@/components/ui/calendar";
 
-export default function CalendarPage() {
+export function CalendarPage() {
   return <Calendar />;
 } 

--- a/src/app/bundles/ui/shadcn/calendar/page.tsx
+++ b/src/app/bundles/ui/shadcn/calendar/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { CalendarPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <CalendarPage />;
 }

--- a/src/app/bundles/ui/shadcn/card/client.tsx
+++ b/src/app/bundles/ui/shadcn/card/client.tsx
@@ -10,7 +10,7 @@ import {
   CardFooter,
 } from "@/components/ui/card";
 
-export default function CardPage() {
+export function CardPage() {
   return (
     <Card>
       <CardHeader>

--- a/src/app/bundles/ui/shadcn/card/page.tsx
+++ b/src/app/bundles/ui/shadcn/card/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { CardPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <CardPage />;
 }

--- a/src/app/bundles/ui/shadcn/carousel/client.tsx
+++ b/src/app/bundles/ui/shadcn/carousel/client.tsx
@@ -2,7 +2,7 @@
 
 import { Carousel, CarouselContent, CarouselItem } from "@/components/ui/carousel";
 
-export default function CarouselPage() {
+export function CarouselPage() {
   return (
     <Carousel>
       <CarouselContent>

--- a/src/app/bundles/ui/shadcn/carousel/page.tsx
+++ b/src/app/bundles/ui/shadcn/carousel/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { CarouselPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <CarouselPage />;
 }

--- a/src/app/bundles/ui/shadcn/checkbox/client.tsx
+++ b/src/app/bundles/ui/shadcn/checkbox/client.tsx
@@ -2,6 +2,6 @@
 
 import { Checkbox } from "@/components/ui/checkbox";
 
-export default function CheckboxPage() {
+export function CheckboxPage() {
   return <Checkbox />;
 } 

--- a/src/app/bundles/ui/shadcn/checkbox/page.tsx
+++ b/src/app/bundles/ui/shadcn/checkbox/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { CheckboxPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <CheckboxPage />;
 }

--- a/src/app/bundles/ui/shadcn/collapsible/client.tsx
+++ b/src/app/bundles/ui/shadcn/collapsible/client.tsx
@@ -2,7 +2,7 @@
 
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
 
-export default function CollapsiblePage() {
+export function CollapsiblePage() {
   return (
     <Collapsible>
       <CollapsibleTrigger>Toggle</CollapsibleTrigger>

--- a/src/app/bundles/ui/shadcn/collapsible/page.tsx
+++ b/src/app/bundles/ui/shadcn/collapsible/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { CollapsiblePage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <CollapsiblePage />;
 }

--- a/src/app/bundles/ui/shadcn/context-menu/client.tsx
+++ b/src/app/bundles/ui/shadcn/context-menu/client.tsx
@@ -2,7 +2,7 @@
 
 import { ContextMenu, ContextMenuTrigger, ContextMenuContent } from "@/components/ui/context-menu";
 
-export default function ContextMenuPage() {
+export function ContextMenuPage() {
   return (
     <ContextMenu>
       <ContextMenuTrigger>Right click me</ContextMenuTrigger>

--- a/src/app/bundles/ui/shadcn/context-menu/page.tsx
+++ b/src/app/bundles/ui/shadcn/context-menu/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { ContextMenuPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <ContextMenuPage />;
 }

--- a/src/app/bundles/ui/shadcn/dialog/client.tsx
+++ b/src/app/bundles/ui/shadcn/dialog/client.tsx
@@ -2,7 +2,7 @@
 
 import { Dialog, DialogTrigger, DialogContent } from "@/components/ui/dialog";
 
-export default function DialogPage() {
+export function DialogPage() {
   return (
     <Dialog>
       <DialogTrigger>Open Dialog</DialogTrigger>

--- a/src/app/bundles/ui/shadcn/dialog/page.tsx
+++ b/src/app/bundles/ui/shadcn/dialog/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { DialogPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <DialogPage />;
 }

--- a/src/app/bundles/ui/shadcn/drawer/client.tsx
+++ b/src/app/bundles/ui/shadcn/drawer/client.tsx
@@ -2,7 +2,7 @@
 
 import { Drawer, DrawerTrigger, DrawerContent } from "@/components/ui/drawer";
 
-export default function DrawerPage() {
+export function DrawerPage() {
   return (
     <Drawer>
       <DrawerTrigger>Open Drawer</DrawerTrigger>

--- a/src/app/bundles/ui/shadcn/drawer/page.tsx
+++ b/src/app/bundles/ui/shadcn/drawer/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { DrawerPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <DrawerPage />;
 }

--- a/src/app/bundles/ui/shadcn/dropdown-menu/client.tsx
+++ b/src/app/bundles/ui/shadcn/dropdown-menu/client.tsx
@@ -2,7 +2,7 @@
 
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent } from "@/components/ui/dropdown-menu";
 
-export default function DropdownMenuPage() {
+export function DropdownMenuPage() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger>Open Menu</DropdownMenuTrigger>

--- a/src/app/bundles/ui/shadcn/dropdown-menu/page.tsx
+++ b/src/app/bundles/ui/shadcn/dropdown-menu/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { DropdownMenuPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <DropdownMenuPage />;
 }

--- a/src/app/bundles/ui/shadcn/form/client.tsx
+++ b/src/app/bundles/ui/shadcn/form/client.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/form";
 import { useForm } from "react-hook-form";
 
-export default function ClientForm() {
+export function ClientForm() {
   const form = useForm<{ email: string }>({
     defaultValues: { email: "" },
   });

--- a/src/app/bundles/ui/shadcn/form/page.tsx
+++ b/src/app/bundles/ui/shadcn/form/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { ClientForm } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <ClientForm />;
 }

--- a/src/app/bundles/ui/shadcn/hover-card/client.tsx
+++ b/src/app/bundles/ui/shadcn/hover-card/client.tsx
@@ -2,7 +2,7 @@
 
 import { HoverCard, HoverCardTrigger, HoverCardContent } from "@/components/ui/hover-card";
 
-export default function HoverCardPage() {
+export function HoverCardPage() {
   return (
     <HoverCard>
       <HoverCardTrigger>Hover me</HoverCardTrigger>

--- a/src/app/bundles/ui/shadcn/hover-card/page.tsx
+++ b/src/app/bundles/ui/shadcn/hover-card/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { HoverCardPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <HoverCardPage />;
 }

--- a/src/app/bundles/ui/shadcn/input/client.tsx
+++ b/src/app/bundles/ui/shadcn/input/client.tsx
@@ -2,6 +2,6 @@
 
 import { Input } from "@/components/ui/input";
 
-export default function InputPage() {
+export function InputPage() {
   return <Input placeholder="Input" />;
 } 

--- a/src/app/bundles/ui/shadcn/input/page.tsx
+++ b/src/app/bundles/ui/shadcn/input/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { InputPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <InputPage />;
 }

--- a/src/app/bundles/ui/shadcn/label/client.tsx
+++ b/src/app/bundles/ui/shadcn/label/client.tsx
@@ -2,6 +2,6 @@
 
 import { Label } from "@/components/ui/label";
 
-export default function LabelPage() {
+export function LabelPage() {
   return <Label>Label</Label>;
 } 

--- a/src/app/bundles/ui/shadcn/label/page.tsx
+++ b/src/app/bundles/ui/shadcn/label/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { LabelPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <LabelPage />;
 }

--- a/src/app/bundles/ui/shadcn/menubar/client.tsx
+++ b/src/app/bundles/ui/shadcn/menubar/client.tsx
@@ -2,6 +2,6 @@
 
 import { Menubar } from "@/components/ui/menubar";
 
-export default function MenubarPage() {
+export function MenubarPage() {
   return <Menubar />;
 } 

--- a/src/app/bundles/ui/shadcn/menubar/page.tsx
+++ b/src/app/bundles/ui/shadcn/menubar/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { MenubarPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <MenubarPage />;
 }

--- a/src/app/bundles/ui/shadcn/navigation-menu/client.tsx
+++ b/src/app/bundles/ui/shadcn/navigation-menu/client.tsx
@@ -2,6 +2,6 @@
 
 import { NavigationMenu } from "@/components/ui/navigation-menu";
 
-export default function NavigationMenuPage() {
+export function NavigationMenuPage() {
   return <NavigationMenu />;
 } 

--- a/src/app/bundles/ui/shadcn/navigation-menu/page.tsx
+++ b/src/app/bundles/ui/shadcn/navigation-menu/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { NavigationMenuPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <NavigationMenuPage />;
 }

--- a/src/app/bundles/ui/shadcn/pagination/client.tsx
+++ b/src/app/bundles/ui/shadcn/pagination/client.tsx
@@ -2,6 +2,6 @@
 
 import { Pagination } from "@/components/ui/pagination";
 
-export default function PaginationPage() {
+export function PaginationPage() {
   return <Pagination />;
 } 

--- a/src/app/bundles/ui/shadcn/pagination/page.tsx
+++ b/src/app/bundles/ui/shadcn/pagination/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { PaginationPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <PaginationPage />;
 }

--- a/src/app/bundles/ui/shadcn/popover/client.tsx
+++ b/src/app/bundles/ui/shadcn/popover/client.tsx
@@ -2,7 +2,7 @@
 
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 
-export default function PopoverPage() {
+export function PopoverPage() {
   return (
     <Popover>
       <PopoverTrigger>Open Popover</PopoverTrigger>

--- a/src/app/bundles/ui/shadcn/popover/page.tsx
+++ b/src/app/bundles/ui/shadcn/popover/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { PopoverPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <PopoverPage />;
 }

--- a/src/app/bundles/ui/shadcn/progress/client.tsx
+++ b/src/app/bundles/ui/shadcn/progress/client.tsx
@@ -2,6 +2,6 @@
 
 import { Progress } from "@/components/ui/progress";
 
-export default function ProgressPage() {
+export function ProgressPage() {
   return <Progress value={50} />;
 } 

--- a/src/app/bundles/ui/shadcn/progress/page.tsx
+++ b/src/app/bundles/ui/shadcn/progress/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { ProgressPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <ProgressPage />;
 }

--- a/src/app/bundles/ui/shadcn/radio-group/client.tsx
+++ b/src/app/bundles/ui/shadcn/radio-group/client.tsx
@@ -2,7 +2,7 @@
 
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 
-export default function RadioGroupPage() {
+export function RadioGroupPage() {
   return (
     <RadioGroup>
       <RadioGroupItem value="1" />

--- a/src/app/bundles/ui/shadcn/radio-group/page.tsx
+++ b/src/app/bundles/ui/shadcn/radio-group/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { RadioGroupPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <RadioGroupPage />;
 }

--- a/src/app/bundles/ui/shadcn/resizable/client.tsx
+++ b/src/app/bundles/ui/shadcn/resizable/client.tsx
@@ -2,7 +2,7 @@
 
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
 
-export default function ResizablePage() {
+export function ResizablePage() {
   return (
     <ResizablePanelGroup direction="horizontal">
       <ResizablePanel>Panel 1</ResizablePanel>

--- a/src/app/bundles/ui/shadcn/resizable/page.tsx
+++ b/src/app/bundles/ui/shadcn/resizable/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { ResizablePage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <ResizablePage />;
 }

--- a/src/app/bundles/ui/shadcn/scroll-area/client.tsx
+++ b/src/app/bundles/ui/shadcn/scroll-area/client.tsx
@@ -2,6 +2,6 @@
 
 import { ScrollArea } from "@/components/ui/scroll-area";
 
-export default function ScrollAreaPage() {
+export function ScrollAreaPage() {
   return <ScrollArea style={{ height: 100 }}>Scroll content</ScrollArea>;
 } 

--- a/src/app/bundles/ui/shadcn/scroll-area/page.tsx
+++ b/src/app/bundles/ui/shadcn/scroll-area/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { ScrollAreaPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <ScrollAreaPage />;
 }

--- a/src/app/bundles/ui/shadcn/select/client.tsx
+++ b/src/app/bundles/ui/shadcn/select/client.tsx
@@ -7,7 +7,7 @@ import {
   SelectTrigger,
 } from "@/components/ui/select";
 
-export default function SelectPage() {
+export function SelectPage() {
   return (
     <Select>
       <SelectTrigger>Select a fruit</SelectTrigger>

--- a/src/app/bundles/ui/shadcn/select/page.tsx
+++ b/src/app/bundles/ui/shadcn/select/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { SelectPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <SelectPage />;
 }

--- a/src/app/bundles/ui/shadcn/separator/client.tsx
+++ b/src/app/bundles/ui/shadcn/separator/client.tsx
@@ -2,6 +2,6 @@
 
 import { Separator } from "@/components/ui/separator";
 
-export default function SeparatorPage() {
+export function SeparatorPage() {
   return <Separator />;
 } 

--- a/src/app/bundles/ui/shadcn/separator/page.tsx
+++ b/src/app/bundles/ui/shadcn/separator/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { SeparatorPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <SeparatorPage />;
 }

--- a/src/app/bundles/ui/shadcn/sheet/client.tsx
+++ b/src/app/bundles/ui/shadcn/sheet/client.tsx
@@ -2,7 +2,7 @@
 
 import { Sheet, SheetTrigger, SheetContent } from "@/components/ui/sheet";
 
-export default function SheetPage() {
+export function SheetPage() {
   return (
     <Sheet>
       <SheetTrigger>Open Sheet</SheetTrigger>

--- a/src/app/bundles/ui/shadcn/sheet/page.tsx
+++ b/src/app/bundles/ui/shadcn/sheet/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { SheetPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <SheetPage />;
 }

--- a/src/app/bundles/ui/shadcn/sidebar/client.tsx
+++ b/src/app/bundles/ui/shadcn/sidebar/client.tsx
@@ -2,7 +2,7 @@
 
 import { SidebarProvider, Sidebar } from "@/components/ui/sidebar";
 
-export default function SidebarPage() {
+export function SidebarPage() {
   return (
     <SidebarProvider>
       <Sidebar />

--- a/src/app/bundles/ui/shadcn/sidebar/page.tsx
+++ b/src/app/bundles/ui/shadcn/sidebar/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { SidebarPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <SidebarPage />;
 }

--- a/src/app/bundles/ui/shadcn/skeleton/client.tsx
+++ b/src/app/bundles/ui/shadcn/skeleton/client.tsx
@@ -2,6 +2,6 @@
 
 import { Skeleton } from "@/components/ui/skeleton";
 
-export default function SkeletonPage() {
+export function SkeletonPage() {
   return <Skeleton style={{ width: 100, height: 20 }} />;
 } 

--- a/src/app/bundles/ui/shadcn/skeleton/page.tsx
+++ b/src/app/bundles/ui/shadcn/skeleton/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { SkeletonPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <SkeletonPage />;
 }

--- a/src/app/bundles/ui/shadcn/slider/client.tsx
+++ b/src/app/bundles/ui/shadcn/slider/client.tsx
@@ -2,6 +2,6 @@
 
 import { Slider } from "@/components/ui/slider";
 
-export default function SliderPage() {
+export function SliderPage() {
   return <Slider />;
 } 

--- a/src/app/bundles/ui/shadcn/slider/page.tsx
+++ b/src/app/bundles/ui/shadcn/slider/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { SliderPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <SliderPage />;
 }

--- a/src/app/bundles/ui/shadcn/sonner/client.tsx
+++ b/src/app/bundles/ui/shadcn/sonner/client.tsx
@@ -2,6 +2,6 @@
 
 import { Toaster } from "@/components/ui/sonner";
 
-export default function SonnerPage() {
+export function SonnerPage() {
   return <Toaster />;
 } 

--- a/src/app/bundles/ui/shadcn/sonner/page.tsx
+++ b/src/app/bundles/ui/shadcn/sonner/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { SonnerPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <SonnerPage />;
 }

--- a/src/app/bundles/ui/shadcn/switch/client.tsx
+++ b/src/app/bundles/ui/shadcn/switch/client.tsx
@@ -2,6 +2,6 @@
 
 import { Switch } from "@/components/ui/switch";
 
-export default function SwitchPage() {
+export function SwitchPage() {
   return <Switch />;
 } 

--- a/src/app/bundles/ui/shadcn/switch/page.tsx
+++ b/src/app/bundles/ui/shadcn/switch/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { SwitchPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <SwitchPage />;
 }

--- a/src/app/bundles/ui/shadcn/table/client.tsx
+++ b/src/app/bundles/ui/shadcn/table/client.tsx
@@ -2,7 +2,7 @@
 
 import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table";
 
-export default function TablePage() {
+export function TablePage() {
   return (
     <Table>
       <TableHeader>

--- a/src/app/bundles/ui/shadcn/table/page.tsx
+++ b/src/app/bundles/ui/shadcn/table/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { TablePage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <TablePage />;
 }

--- a/src/app/bundles/ui/shadcn/tabs/client.tsx
+++ b/src/app/bundles/ui/shadcn/tabs/client.tsx
@@ -2,7 +2,7 @@
 
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 
-export default function TabsPage() {
+export function TabsPage() {
   return (
     <Tabs defaultValue="tab1">
       <TabsList>

--- a/src/app/bundles/ui/shadcn/tabs/page.tsx
+++ b/src/app/bundles/ui/shadcn/tabs/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { TabsPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <TabsPage />;
 }

--- a/src/app/bundles/ui/shadcn/textarea/client.tsx
+++ b/src/app/bundles/ui/shadcn/textarea/client.tsx
@@ -2,6 +2,6 @@
 
 import { Textarea } from "@/components/ui/textarea";
 
-export default function TextareaPage() {
+export function TextareaPage() {
   return <Textarea placeholder="Textarea" />;
 } 

--- a/src/app/bundles/ui/shadcn/textarea/page.tsx
+++ b/src/app/bundles/ui/shadcn/textarea/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { TextareaPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <TextareaPage />;
 }

--- a/src/app/bundles/ui/shadcn/toggle-group/client.tsx
+++ b/src/app/bundles/ui/shadcn/toggle-group/client.tsx
@@ -2,7 +2,7 @@
 
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 
-export default function ToggleGroupPage() {
+export function ToggleGroupPage() {
   return (
     <ToggleGroup type="single">
       <ToggleGroupItem value="1">Item 1</ToggleGroupItem>

--- a/src/app/bundles/ui/shadcn/toggle-group/page.tsx
+++ b/src/app/bundles/ui/shadcn/toggle-group/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { ToggleGroupPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <ToggleGroupPage />;
 }

--- a/src/app/bundles/ui/shadcn/toggle/client.tsx
+++ b/src/app/bundles/ui/shadcn/toggle/client.tsx
@@ -2,6 +2,6 @@
 
 import { Toggle } from "@/components/ui/toggle";
 
-export default function TogglePage() {
+export function TogglePage() {
   return <Toggle>Toggle</Toggle>;
 } 

--- a/src/app/bundles/ui/shadcn/toggle/page.tsx
+++ b/src/app/bundles/ui/shadcn/toggle/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { TogglePage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <TogglePage />;
 }

--- a/src/app/bundles/ui/shadcn/tooltip/client.tsx
+++ b/src/app/bundles/ui/shadcn/tooltip/client.tsx
@@ -2,7 +2,7 @@
 
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 
-export default function TooltipPage() {
+export function TooltipPage() {
   return (
     <Tooltip>
       <TooltipTrigger>Hover me</TooltipTrigger>

--- a/src/app/bundles/ui/shadcn/tooltip/page.tsx
+++ b/src/app/bundles/ui/shadcn/tooltip/page.tsx
@@ -1,5 +1,5 @@
-import Client from "./client";
+import { TooltipPage } from "./client";
 
 export default function Page() {
-  return <Client />;
+  return <TooltipPage />;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
-import SearchBlock from "@/blocks/search";
-import DefaultLayout from "@/layout/default";
+import { SearchBlock } from "@/blocks/search";
+import { DefaultLayout } from "@/layout/default";
 
 export default function Home() {
   return (

--- a/src/app/ui/layout.tsx
+++ b/src/app/ui/layout.tsx
@@ -1,5 +1,5 @@
-import Header from "@/components/header";
-import SidebarNav from "@/components/sidebar-nav";
+import { Header } from "@/components/header";
+import { SidebarNav } from "@/components/sidebar-nav";
 import { Container } from "@/components/container";
 import { cn } from "@/lib/utils";
 

--- a/src/blocks/search.tsx
+++ b/src/blocks/search.tsx
@@ -1,9 +1,9 @@
 import { Container } from "@/components/container";
-import HeroBackground from "@/components/hero-background";
+import { HeroBackground } from "@/components/hero-background";
 import SearchDirect from "@/components/search-direct";
 import { Section } from "@/components/section";
 
-export default function SearchBlock() {
+export function SearchBlock() {
   return (
     <Section spacing="xlarge" background={<HeroBackground />} className="min-h-screen flex flex-col items-center justify-center">
       <Container className="relative">

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,11 +1,11 @@
 "use client"
 
 import Link from "next/link";
-import SearchButton from "./search-button";
+import { SearchButton } from "./search-button";
 import { Container } from "./container";
 import { appConfig } from "@/config/app";
 
-export default function Header() {
+export function Header() {
   return (
     <header className="border-grid py-2 sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <Container className="flex h-12 items-center gap-4">

--- a/src/components/hero-background.tsx
+++ b/src/components/hero-background.tsx
@@ -1,6 +1,6 @@
 import { useId } from "react";
 
-export default function HeroBackground() {
+export function HeroBackground() {
   const patternId = useId();
 
   return (

--- a/src/components/search-button.tsx
+++ b/src/components/search-button.tsx
@@ -3,9 +3,9 @@
 import { useState } from "react";
 import { SearchIcon } from "lucide-react";
 import { CommandShortcut } from "@/components/ui/command";
-import SearchDialog from "./search-dialog";
+import { SearchDialog } from "./search-dialog";
 
-export default function SearchButton({ className }: { className?: string }) {
+export function SearchButton({ className }: { className?: string }) {
   const [open, setOpen] = useState(false);
   return (
     <>

--- a/src/components/search-command.tsx
+++ b/src/components/search-command.tsx
@@ -26,7 +26,7 @@ interface SearchCommandProps {
   onSelect?: (result: SearchResult) => void;
 }
 
-export default function SearchCommand({
+export function SearchCommand({
   placeholder = "Search components...",
   className,
   onSelect,

--- a/src/components/search-dialog.tsx
+++ b/src/components/search-dialog.tsx
@@ -2,9 +2,9 @@
 
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { useEffect } from "react";
-import SearchCommand from "./search-command";
+import { SearchCommand } from "./search-command";
 
-export default function SearchDialog({
+export function SearchDialog({
   open,
   onOpenChange,
 }: {

--- a/src/components/search-direct.tsx
+++ b/src/components/search-direct.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import SearchCommand from "./search-command";
+import { SearchCommand } from "./search-command";
 
-export default function SearchDirect({ className }: { className?: string }) {
+export function SearchDirect({ className }: { className?: string }) {
 
   return (
     <div className={`rounded-md border bg-background overflow-hidden ${className ?? ""}`}>

--- a/src/components/sidebar-nav.tsx
+++ b/src/components/sidebar-nav.tsx
@@ -12,7 +12,7 @@ export interface SidebarKit {
   components: string[];
 }
 
-export default async function SidebarNav() {
+export async function SidebarNav() {
   const kits = await getUiIndex();
   return (
     <aside className="border-grid fixed top-14 z-30 hidden h-[calc(100vh-3.5rem)] w-full shrink-0 border-r md:sticky md:block">

--- a/src/layout/default.tsx
+++ b/src/layout/default.tsx
@@ -4,7 +4,7 @@ interface DefaultLayoutProps {
   children: ReactNode;
 }
 
-export default function DefaultLayout({ children }: DefaultLayoutProps) {
+export function DefaultLayout({ children }: DefaultLayoutProps) {
   return (
     <div className="relative flex min-h-screen flex-col">
       <header className="top-0 z-2 w-full text-black dark:text-white sticky h-0">


### PR DESCRIPTION
## Summary
- refactor all component files to use named exports
- update imports accordingly
- adjust shadcn page imports for named client components

## Testing
- `pnpm lint`
