### PR TITLE
Add realistic Hero UI examples

### DIFF
--- a/src/app/bundles/ui/heroui/accordion/client.tsx
+++ b/src/app/bundles/ui/heroui/accordion/client.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import {Accordion, AccordionItem} from "@heroui/react";
+
+export function AccordionPage() {
+  const defaultContent =
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.";
+  return (
+    <Accordion>
+      <AccordionItem key="1" aria-label="Accordion 1" title="Accordion 1">
+        {defaultContent}
+      </AccordionItem>
+      <AccordionItem key="2" aria-label="Accordion 2" title="Accordion 2">
+        {defaultContent}
+      </AccordionItem>
+      <AccordionItem key="3" aria-label="Accordion 3" title="Accordion 3">
+        {defaultContent}
+      </AccordionItem>
+    </Accordion>
+  );
+}

--- a/src/app/bundles/ui/heroui/accordion/page.tsx
+++ b/src/app/bundles/ui/heroui/accordion/page.tsx
@@ -1,0 +1,5 @@
+import { AccordionPage } from "./client";
+
+export default function Page() {
+  return <AccordionPage />;
+}

--- a/src/app/bundles/ui/heroui/alert/client.tsx
+++ b/src/app/bundles/ui/heroui/alert/client.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import {Alert} from "@heroui/react";
+
+export function AlertPage() {
+  const title = "This is an alert";
+  const description = "Thanks for subscribing to our newsletter!";
+  return (
+    <div className="flex items-center justify-center w-full">
+      <Alert description={description} title={title} />
+    </div>
+  );
+}

--- a/src/app/bundles/ui/heroui/alert/page.tsx
+++ b/src/app/bundles/ui/heroui/alert/page.tsx
@@ -1,0 +1,5 @@
+import { AlertPage } from "./client";
+
+export default function Page() {
+  return <AlertPage />;
+}

--- a/src/app/bundles/ui/heroui/autocomplete/client.tsx
+++ b/src/app/bundles/ui/heroui/autocomplete/client.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import {Autocomplete, AutocompleteItem} from "@heroui/react";
+
+export function AutocompletePage() {
+  const animals = [
+    {label: "Cat", key: "cat"},
+    {label: "Dog", key: "dog"},
+    {label: "Elephant", key: "elephant"},
+    {label: "Lion", key: "lion"},
+    {label: "Tiger", key: "tiger"},
+    {label: "Giraffe", key: "giraffe"},
+  ];
+  return (
+    <Autocomplete className="max-w-xs" label="Select an animal">
+      {animals.map((animal) => (
+        <AutocompleteItem key={animal.key}>{animal.label}</AutocompleteItem>
+      ))}
+    </Autocomplete>
+  );
+}

--- a/src/app/bundles/ui/heroui/autocomplete/page.tsx
+++ b/src/app/bundles/ui/heroui/autocomplete/page.tsx
@@ -1,0 +1,5 @@
+import { AutocompletePage } from "./client";
+
+export default function Page() {
+  return <AutocompletePage />;
+}

--- a/src/app/bundles/ui/heroui/avatar/client.tsx
+++ b/src/app/bundles/ui/heroui/avatar/client.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import {Avatar} from "@heroui/react";
+
+export function AvatarPage() {
+  return (
+    <div className="flex gap-3 items-center">
+      <Avatar src="https://i.pravatar.cc/150?u=a042581f4e29026024d" />
+      <Avatar name="Junior" />
+      <Avatar src="https://i.pravatar.cc/150?u=a042581f4e29026704d" />
+      <Avatar name="Jane" />
+      <Avatar src="https://i.pravatar.cc/150?u=a04258114e29026702d" />
+      <Avatar name="Joe" />
+    </div>
+  );
+}

--- a/src/app/bundles/ui/heroui/avatar/page.tsx
+++ b/src/app/bundles/ui/heroui/avatar/page.tsx
@@ -1,0 +1,5 @@
+import { AvatarPage } from "./client";
+
+export default function Page() {
+  return <AvatarPage />;
+}

--- a/src/app/bundles/ui/heroui/badge/client.tsx
+++ b/src/app/bundles/ui/heroui/badge/client.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import {Badge} from "@heroui/react";
+
+export function BadgePage() {
+  return (
+    <div className="flex gap-2">
+      <Badge>Default</Badge>
+      <Badge color="primary">Primary</Badge>
+    </div>
+  );
+}

--- a/src/app/bundles/ui/heroui/badge/page.tsx
+++ b/src/app/bundles/ui/heroui/badge/page.tsx
@@ -1,0 +1,5 @@
+import { BadgePage } from "./client";
+
+export default function Page() {
+  return <BadgePage />;
+}

--- a/src/app/bundles/ui/heroui/breadcrumbs/client.tsx
+++ b/src/app/bundles/ui/heroui/breadcrumbs/client.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import {Breadcrumbs, BreadcrumbItem} from "@heroui/react";
+
+export function BreadcrumbsPage() {
+  return (
+    <Breadcrumbs>
+      <BreadcrumbItem>Home</BreadcrumbItem>
+      <BreadcrumbItem>Music</BreadcrumbItem>
+      <BreadcrumbItem>Artist</BreadcrumbItem>
+      <BreadcrumbItem>Album</BreadcrumbItem>
+      <BreadcrumbItem>Song</BreadcrumbItem>
+    </Breadcrumbs>
+  );
+}

--- a/src/app/bundles/ui/heroui/breadcrumbs/page.tsx
+++ b/src/app/bundles/ui/heroui/breadcrumbs/page.tsx
@@ -1,0 +1,5 @@
+import { BreadcrumbsPage } from "./client";
+
+export default function Page() {
+  return <BreadcrumbsPage />;
+}

--- a/src/app/bundles/ui/heroui/button/client.tsx
+++ b/src/app/bundles/ui/heroui/button/client.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import {Button} from "@heroui/react";
+
+export function ButtonPage() {
+  return (
+    <div className="flex gap-2">
+      <Button color="primary">Primary</Button>
+      <Button color="secondary">Secondary</Button>
+    </div>
+  );
+}

--- a/src/app/bundles/ui/heroui/button/page.tsx
+++ b/src/app/bundles/ui/heroui/button/page.tsx
@@ -1,0 +1,5 @@
+import { ButtonPage } from "./client";
+
+export default function Page() {
+  return <ButtonPage />;
+}

--- a/src/app/bundles/ui/heroui/calendar/client.tsx
+++ b/src/app/bundles/ui/heroui/calendar/client.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import {Calendar} from "@heroui/react";
+
+export function CalendarPage() {
+  return <Calendar />;
+}

--- a/src/app/bundles/ui/heroui/calendar/page.tsx
+++ b/src/app/bundles/ui/heroui/calendar/page.tsx
@@ -1,0 +1,5 @@
+import { CalendarPage } from "./client";
+
+export default function Page() {
+  return <CalendarPage />;
+}

--- a/src/app/bundles/ui/heroui/card/client.tsx
+++ b/src/app/bundles/ui/heroui/card/client.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import {Card, CardHeader, CardBody} from "@heroui/react";
+
+export function CardPage() {
+  return (
+    <Card className="max-w-xs">
+      <CardHeader>Card Title</CardHeader>
+      <CardBody>Card content</CardBody>
+    </Card>
+  );
+}

--- a/src/app/bundles/ui/heroui/card/page.tsx
+++ b/src/app/bundles/ui/heroui/card/page.tsx
@@ -1,0 +1,5 @@
+import { CardPage } from "./client";
+
+export default function Page() {
+  return <CardPage />;
+}

--- a/src/app/bundles/ui/heroui/checkbox/client.tsx
+++ b/src/app/bundles/ui/heroui/checkbox/client.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import {Checkbox} from "@heroui/react";
+
+export function CheckboxPage() {
+  return <Checkbox>Checkbox</Checkbox>;
+}

--- a/src/app/bundles/ui/heroui/checkbox/page.tsx
+++ b/src/app/bundles/ui/heroui/checkbox/page.tsx
@@ -1,0 +1,5 @@
+import { CheckboxPage } from "./client";
+
+export default function Page() {
+  return <CheckboxPage />;
+}

--- a/src/app/bundles/ui/heroui/chip/client.tsx
+++ b/src/app/bundles/ui/heroui/chip/client.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import {Chip} from "@heroui/react";
+
+export function ChipPage() {
+  return <Chip>Chip</Chip>;
+}

--- a/src/app/bundles/ui/heroui/chip/page.tsx
+++ b/src/app/bundles/ui/heroui/chip/page.tsx
@@ -1,0 +1,5 @@
+import { ChipPage } from "./client";
+
+export default function Page() {
+  return <ChipPage />;
+}

--- a/src/app/bundles/ui/heroui/code/client.tsx
+++ b/src/app/bundles/ui/heroui/code/client.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import {Code} from "@heroui/react";
+
+export function CodePage() {
+  return <Code>&lt;Code /&gt;</Code>;
+}

--- a/src/app/bundles/ui/heroui/code/page.tsx
+++ b/src/app/bundles/ui/heroui/code/page.tsx
@@ -1,0 +1,5 @@
+import { CodePage } from "./client";
+
+export default function Page() {
+  return <CodePage />;
+}

--- a/src/app/bundles/ui/heroui/date-input/client.tsx
+++ b/src/app/bundles/ui/heroui/date-input/client.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import {DateInput} from "@heroui/react";
+
+export function DateInputPage() {
+  return <DateInput label="Date" className="max-w-xs" />;
+}

--- a/src/app/bundles/ui/heroui/date-input/page.tsx
+++ b/src/app/bundles/ui/heroui/date-input/page.tsx
@@ -1,0 +1,5 @@
+import { DateInputPage } from "./client";
+
+export default function Page() {
+  return <DateInputPage />;
+}

--- a/src/app/bundles/ui/heroui/date-picker/client.tsx
+++ b/src/app/bundles/ui/heroui/date-picker/client.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import {DatePicker} from "@heroui/react";
+
+export function DatePickerPage() {
+  return <DatePicker label="Pick a date" className="max-w-xs" />;
+}

--- a/src/app/bundles/ui/heroui/date-picker/page.tsx
+++ b/src/app/bundles/ui/heroui/date-picker/page.tsx
@@ -1,0 +1,5 @@
+import { DatePickerPage } from "./client";
+
+export default function Page() {
+  return <DatePickerPage />;
+}

--- a/src/app/bundles/ui/heroui/divider/client.tsx
+++ b/src/app/bundles/ui/heroui/divider/client.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import {Divider} from "@heroui/react";
+
+export function DividerPage() {
+  return (
+    <div>
+      <p>Content above</p>
+      <Divider className="my-2" />
+      <p>Content below</p>
+    </div>
+  );
+}

--- a/src/app/bundles/ui/heroui/divider/page.tsx
+++ b/src/app/bundles/ui/heroui/divider/page.tsx
@@ -1,0 +1,5 @@
+import { DividerPage } from "./client";
+
+export default function Page() {
+  return <DividerPage />;
+}

--- a/src/app/bundles/ui/heroui/drawer/client.tsx
+++ b/src/app/bundles/ui/heroui/drawer/client.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerBody,
+  DrawerFooter,
+  useDisclosure,
+} from "@heroui/react";
+
+export function DrawerPage() {
+  const {isOpen, onOpen, onOpenChange} = useDisclosure();
+  return (
+    <>
+      <button onClick={onOpen}>Open Drawer</button>
+      <Drawer isOpen={isOpen} onOpenChange={onOpenChange}>
+        <DrawerContent>
+          {(onClose) => (
+            <>
+              <DrawerHeader className="flex flex-col gap-1">Drawer Title</DrawerHeader>
+              <DrawerBody>
+                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+              </DrawerBody>
+              <DrawerFooter>
+                <button onClick={onClose}>Close</button>
+                <button onClick={onClose}>Action</button>
+              </DrawerFooter>
+            </>
+          )}
+        </DrawerContent>
+      </Drawer>
+    </>
+  );
+}

--- a/src/app/bundles/ui/heroui/drawer/page.tsx
+++ b/src/app/bundles/ui/heroui/drawer/page.tsx
@@ -1,0 +1,5 @@
+import { DrawerPage } from "./client";
+
+export default function Page() {
+  return <DrawerPage />;
+}

--- a/src/app/bundles/ui/heroui/dropdown/client.tsx
+++ b/src/app/bundles/ui/heroui/dropdown/client.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import {Dropdown, DropdownTrigger, DropdownMenu, DropdownItem} from "@heroui/react";
+
+export function DropdownPage() {
+  return (
+    <Dropdown>
+      <DropdownTrigger>
+        <button>Open Menu</button>
+      </DropdownTrigger>
+      <DropdownMenu aria-label="Static Actions">
+        <DropdownItem key="new">New file</DropdownItem>
+        <DropdownItem key="copy">Copy link</DropdownItem>
+        <DropdownItem key="edit">Edit file</DropdownItem>
+        <DropdownItem key="delete" className="text-danger" color="danger">
+          Delete file
+        </DropdownItem>
+      </DropdownMenu>
+    </Dropdown>
+  );
+}

--- a/src/app/bundles/ui/heroui/dropdown/page.tsx
+++ b/src/app/bundles/ui/heroui/dropdown/page.tsx
@@ -1,0 +1,5 @@
+import { DropdownPage } from "./client";
+
+export default function Page() {
+  return <DropdownPage />;
+}

--- a/src/app/bundles/ui/heroui/form/client.tsx
+++ b/src/app/bundles/ui/heroui/form/client.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import React from "react";
+import {Form} from "@heroui/react";
+
+export function FormPage() {
+  const [submitted, setSubmitted] = React.useState<Record<string, FormDataEntryValue> | null>(
+    null,
+  );
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const data = Object.fromEntries(new FormData(e.currentTarget));
+    setSubmitted(data);
+  };
+
+  return (
+    <Form className="w-full max-w-xs" onSubmit={onSubmit}>
+      <input name="email" placeholder="Enter your email" type="email" />
+      <button type="submit">Submit</button>
+      {submitted && (
+        <div className="text-small text-default-500">
+          You submitted: <code>{JSON.stringify(submitted)}</code>
+        </div>
+      )}
+    </Form>
+  );
+}

--- a/src/app/bundles/ui/heroui/form/page.tsx
+++ b/src/app/bundles/ui/heroui/form/page.tsx
@@ -1,0 +1,5 @@
+import { FormPage } from "./client";
+
+export default function Page() {
+  return <FormPage />;
+}

--- a/src/app/bundles/ui/heroui/image/client.tsx
+++ b/src/app/bundles/ui/heroui/image/client.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import {Image} from "@heroui/react";
+
+export function ImagePage() {
+  return (
+    <Image
+      alt="HeroUI hero Image"
+      src="https://heroui.com/images/hero-card-complete.jpeg"
+      width={300}
+    />
+  );
+}

--- a/src/app/bundles/ui/heroui/image/page.tsx
+++ b/src/app/bundles/ui/heroui/image/page.tsx
@@ -1,0 +1,5 @@
+import { ImagePage } from "./client";
+
+export default function Page() {
+  return <ImagePage />;
+}

--- a/src/app/bundles/ui/heroui/input-otp/client.tsx
+++ b/src/app/bundles/ui/heroui/input-otp/client.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import React from "react";
+import {InputOtp} from "@heroui/react";
+
+export function InputOtpPage() {
+  const [value, setValue] = React.useState("");
+  return (
+    <div>
+      <InputOtp length={4} value={value} onValueChange={setValue} />
+      <div className="text-small text-default-500">
+        OTP value: <span className="text-md font-medium">{value}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/app/bundles/ui/heroui/input-otp/page.tsx
+++ b/src/app/bundles/ui/heroui/input-otp/page.tsx
@@ -1,0 +1,5 @@
+import { InputOtpPage } from "./client";
+
+export default function Page() {
+  return <InputOtpPage />;
+}

--- a/src/app/bundles/ui/heroui/input/client.tsx
+++ b/src/app/bundles/ui/heroui/input/client.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import {Input} from "@heroui/react";
+
+export function InputPage() {
+  return (
+    <div className="flex w-full flex-wrap md:flex-nowrap gap-4">
+      <Input label="Email" type="email" />
+      <Input label="Email" placeholder="Enter your email" type="email" />
+    </div>
+  );
+}

--- a/src/app/bundles/ui/heroui/input/page.tsx
+++ b/src/app/bundles/ui/heroui/input/page.tsx
@@ -1,0 +1,5 @@
+import { InputPage } from "./client";
+
+export default function Page() {
+  return <InputPage />;
+}

--- a/src/app/bundles/ui/heroui/kbd/client.tsx
+++ b/src/app/bundles/ui/heroui/kbd/client.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import {Kbd} from "@heroui/react";
+
+export function KbdPage() {
+  return <Kbd keys={["command"]}>K</Kbd>;
+}

--- a/src/app/bundles/ui/heroui/kbd/page.tsx
+++ b/src/app/bundles/ui/heroui/kbd/page.tsx
@@ -1,0 +1,5 @@
+import { KbdPage } from "./client";
+
+export default function Page() {
+  return <KbdPage />;
+}

--- a/src/app/bundles/ui/heroui/link/client.tsx
+++ b/src/app/bundles/ui/heroui/link/client.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import {Link} from "@heroui/react";
+
+export function LinkPage() {
+  return <Link href="#">Default Link</Link>;
+}

--- a/src/app/bundles/ui/heroui/link/page.tsx
+++ b/src/app/bundles/ui/heroui/link/page.tsx
@@ -1,0 +1,5 @@
+import { LinkPage } from "./client";
+
+export default function Page() {
+  return <LinkPage />;
+}

--- a/src/app/bundles/ui/heroui/listbox/client.tsx
+++ b/src/app/bundles/ui/heroui/listbox/client.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import {Listbox, ListboxItem} from "@heroui/react";
+
+export function ListboxPage() {
+  return (
+    <div className="w-full max-w-[260px] border-small px-1 py-2 rounded-small border-default-200 dark:border-default-100">
+      <Listbox aria-label="Actions" onAction={(key) => alert(key)}>
+        <ListboxItem key="new">New file</ListboxItem>
+        <ListboxItem key="copy">Copy link</ListboxItem>
+        <ListboxItem key="edit">Edit file</ListboxItem>
+        <ListboxItem key="delete" className="text-danger" color="danger">
+          Delete file
+        </ListboxItem>
+      </Listbox>
+    </div>
+  );
+}

--- a/src/app/bundles/ui/heroui/listbox/page.tsx
+++ b/src/app/bundles/ui/heroui/listbox/page.tsx
@@ -1,0 +1,5 @@
+import { ListboxPage } from "./client";
+
+export default function Page() {
+  return <ListboxPage />;
+}

--- a/src/app/bundles/ui/heroui/menu/client.tsx
+++ b/src/app/bundles/ui/heroui/menu/client.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import {Menu, MenuTrigger, MenuItem, MenuList} from "@heroui/react";
+
+export function MenuPage() {
+  return (
+    <Menu>
+      <MenuTrigger>
+        <button>Open Menu</button>
+      </MenuTrigger>
+      <MenuList aria-label="Menu">
+        <MenuItem key="profile">Profile</MenuItem>
+        <MenuItem key="settings">Settings</MenuItem>
+        <MenuItem key="logout">Log Out</MenuItem>
+      </MenuList>
+    </Menu>
+  );
+}

--- a/src/app/bundles/ui/heroui/menu/page.tsx
+++ b/src/app/bundles/ui/heroui/menu/page.tsx
@@ -1,0 +1,5 @@
+import { MenuPage } from "./client";
+
+export default function Page() {
+  return <MenuPage />;
+}

--- a/src/app/bundles/ui/heroui/modal/client.tsx
+++ b/src/app/bundles/ui/heroui/modal/client.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import {
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  Button,
+  useDisclosure,
+} from "@heroui/react";
+
+export function ModalPage() {
+  const {isOpen, onOpen, onOpenChange} = useDisclosure();
+  return (
+    <>
+      <Button onClick={onOpen}>Open Modal</Button>
+      <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
+        <ModalContent>
+          {(onClose) => (
+            <>
+              <ModalHeader className="flex flex-col gap-1">Modal Title</ModalHeader>
+              <ModalBody>
+                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+              </ModalBody>
+              <ModalFooter>
+                <Button color="danger" variant="light" onClick={onClose}>
+                  Close
+                </Button>
+                <Button color="primary" onClick={onClose}>
+                  Action
+                </Button>
+              </ModalFooter>
+            </>
+          )}
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}

--- a/src/app/bundles/ui/heroui/modal/page.tsx
+++ b/src/app/bundles/ui/heroui/modal/page.tsx
@@ -1,0 +1,5 @@
+import { ModalPage } from "./client";
+
+export default function Page() {
+  return <ModalPage />;
+}

--- a/src/app/bundles/ui/heroui/navbar/client.tsx
+++ b/src/app/bundles/ui/heroui/navbar/client.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import {
+  Navbar,
+  NavbarBrand,
+  NavbarContent,
+  NavbarItem,
+} from "@heroui/react";
+
+export const AcmeLogo = () => (
+  <svg fill="none" height="36" viewBox="0 0 32 32" width="36">
+    <path
+      clipRule="evenodd"
+      d="M17.6482 10.1305L15.8785 7.02583L7.02979 22.5499H10.5278L17.6482 10.1305ZM19.8798 14.0457L18.11 17.1983L19.394 19.4511H16.8453L15.1056 22.5499H24.7272L19.8798 14.0457Z"
+      fill="currentColor"
+      fillRule="evenodd"
+    />
+  </svg>
+);
+
+export function NavbarPage() {
+  return (
+    <Navbar>
+      <NavbarBrand>
+        <AcmeLogo />
+        <p className="font-bold text-inherit">ACME</p>
+      </NavbarBrand>
+      <NavbarContent className="hidden sm:flex gap-4" justify="center">
+        <NavbarItem>
+          <a href="#">Features</a>
+        </NavbarItem>
+        <NavbarItem isActive>
+          <a aria-current="page" href="#">
+            Customers
+          </a>
+        </NavbarItem>
+        <NavbarItem>
+          <a href="#">Integrations</a>
+        </NavbarItem>
+      </NavbarContent>
+      <NavbarContent justify="end">
+        <NavbarItem className="hidden lg:flex">
+          <a href="#">Login</a>
+        </NavbarItem>
+        <NavbarItem>
+          <button>Sign Up</button>
+        </NavbarItem>
+      </NavbarContent>
+    </Navbar>
+  );
+}

--- a/src/app/bundles/ui/heroui/navbar/page.tsx
+++ b/src/app/bundles/ui/heroui/navbar/page.tsx
@@ -1,0 +1,5 @@
+import { NavbarPage } from "./client";
+
+export default function Page() {
+  return <NavbarPage />;
+}

--- a/src/app/bundles/ui/heroui/number-input/client.tsx
+++ b/src/app/bundles/ui/heroui/number-input/client.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import {NumberInput} from "@heroui/react";
+
+export function NumberInputPage() {
+  return <NumberInput className="max-w-xs" placeholder="Enter the amount" />;
+}

--- a/src/app/bundles/ui/heroui/number-input/page.tsx
+++ b/src/app/bundles/ui/heroui/number-input/page.tsx
@@ -1,0 +1,5 @@
+import { NumberInputPage } from "./client";
+
+export default function Page() {
+  return <NumberInputPage />;
+}

--- a/src/app/bundles/ui/heroui/pagination/client.tsx
+++ b/src/app/bundles/ui/heroui/pagination/client.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import {Pagination} from "@heroui/react";
+
+export function PaginationPage() {
+  return <Pagination initialPage={1} total={10} />;
+}

--- a/src/app/bundles/ui/heroui/pagination/page.tsx
+++ b/src/app/bundles/ui/heroui/pagination/page.tsx
@@ -1,0 +1,5 @@
+import { PaginationPage } from "./client";
+
+export default function Page() {
+  return <PaginationPage />;
+}

--- a/src/app/bundles/ui/heroui/popover/client.tsx
+++ b/src/app/bundles/ui/heroui/popover/client.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import {Popover, PopoverTrigger, PopoverContent} from "@heroui/react";
+
+export function PopoverPage() {
+  return (
+    <Popover placement="right">
+      <PopoverTrigger>
+        <button>Open Popover</button>
+      </PopoverTrigger>
+      <PopoverContent>
+        <div className="px-1 py-2">
+          <div className="text-small font-bold">Popover Content</div>
+          <div className="text-tiny">This is the popover content</div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/app/bundles/ui/heroui/popover/page.tsx
+++ b/src/app/bundles/ui/heroui/popover/page.tsx
@@ -1,0 +1,5 @@
+import { PopoverPage } from "./client";
+
+export default function Page() {
+  return <PopoverPage />;
+}

--- a/src/app/bundles/ui/heroui/progress/client.tsx
+++ b/src/app/bundles/ui/heroui/progress/client.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import {Progress} from "@heroui/react";
+
+export function ProgressPage() {
+  return <Progress aria-label="Loading..." className="max-w-md" value={60} />;
+}

--- a/src/app/bundles/ui/heroui/progress/page.tsx
+++ b/src/app/bundles/ui/heroui/progress/page.tsx
@@ -1,0 +1,5 @@
+import { ProgressPage } from "./client";
+
+export default function Page() {
+  return <ProgressPage />;
+}

--- a/src/app/bundles/ui/heroui/radio/client.tsx
+++ b/src/app/bundles/ui/heroui/radio/client.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import {RadioGroup, Radio} from "@heroui/react";
+
+export function RadioPage() {
+  return (
+    <RadioGroup label="Select your favorite city">
+      <Radio value="buenos-aires">Buenos Aires</Radio>
+      <Radio value="sydney">Sydney</Radio>
+      <Radio value="san-francisco">San Francisco</Radio>
+      <Radio value="london">London</Radio>
+      <Radio value="tokyo">Tokyo</Radio>
+    </RadioGroup>
+  );
+}

--- a/src/app/bundles/ui/heroui/radio/page.tsx
+++ b/src/app/bundles/ui/heroui/radio/page.tsx
@@ -1,0 +1,5 @@
+import { RadioPage } from "./client";
+
+export default function Page() {
+  return <RadioPage />;
+}

--- a/src/app/bundles/ui/heroui/ripple/client.tsx
+++ b/src/app/bundles/ui/heroui/ripple/client.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import {Ripple} from "@heroui/react";
+
+export function RipplePage() {
+  return <Ripple as="button">Click me</Ripple>;
+}

--- a/src/app/bundles/ui/heroui/ripple/page.tsx
+++ b/src/app/bundles/ui/heroui/ripple/page.tsx
@@ -1,0 +1,5 @@
+import { RipplePage } from "./client";
+
+export default function Page() {
+  return <RipplePage />;
+}

--- a/src/app/bundles/ui/heroui/scroll-shadow/client.tsx
+++ b/src/app/bundles/ui/heroui/scroll-shadow/client.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import {ScrollShadow} from "@heroui/react";
+
+export function ScrollShadowPage() {
+  return (
+    <ScrollShadow className="h-20 w-[340px]">
+      <p>Item 1</p>
+      <p>Item 2</p>
+      <p>Item 3</p>
+      <p>Item 4</p>
+      <p>Item 5</p>
+      <p>Item 6</p>
+      <p>Item 7</p>
+      <p>Item 8</p>
+    </ScrollShadow>
+  );
+}

--- a/src/app/bundles/ui/heroui/scroll-shadow/page.tsx
+++ b/src/app/bundles/ui/heroui/scroll-shadow/page.tsx
@@ -1,0 +1,5 @@
+import { ScrollShadowPage } from "./client";
+
+export default function Page() {
+  return <ScrollShadowPage />;
+}

--- a/src/app/bundles/ui/heroui/select/client.tsx
+++ b/src/app/bundles/ui/heroui/select/client.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import {Select, SelectItem} from "@heroui/react";
+
+export function SelectPage() {
+  const animals = [
+    {key: "cat", label: "Cat"},
+    {key: "dog", label: "Dog"},
+    {key: "elephant", label: "Elephant"},
+    {key: "lion", label: "Lion"},
+  ];
+  return (
+    <div className="flex w-full flex-wrap md:flex-nowrap gap-4">
+      <Select className="max-w-xs" label="Select an animal">
+        {animals.map((animal) => (
+          <SelectItem key={animal.key}>{animal.label}</SelectItem>
+        ))}
+      </Select>
+      <Select className="max-w-xs" label="Favorite Animal" placeholder="Select an animal">
+        {animals.map((animal) => (
+          <SelectItem key={animal.key}>{animal.label}</SelectItem>
+        ))}
+      </Select>
+    </div>
+  );
+}

--- a/src/app/bundles/ui/heroui/select/page.tsx
+++ b/src/app/bundles/ui/heroui/select/page.tsx
@@ -1,0 +1,5 @@
+import { SelectPage } from "./client";
+
+export default function Page() {
+  return <SelectPage />;
+}

--- a/src/app/bundles/ui/heroui/skeleton/client.tsx
+++ b/src/app/bundles/ui/heroui/skeleton/client.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import {Skeleton} from "@heroui/react";
+
+export function SkeletonPage() {
+  return (
+    <Skeleton className="rounded-lg">
+      <div className="h-24 rounded-lg bg-default-300" />
+    </Skeleton>
+  );
+}

--- a/src/app/bundles/ui/heroui/skeleton/page.tsx
+++ b/src/app/bundles/ui/heroui/skeleton/page.tsx
@@ -1,0 +1,5 @@
+import { SkeletonPage } from "./client";
+
+export default function Page() {
+  return <SkeletonPage />;
+}

--- a/src/app/bundles/ui/heroui/slider/client.tsx
+++ b/src/app/bundles/ui/heroui/slider/client.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import {Slider} from "@heroui/react";
+
+export function SliderPage() {
+  return (
+    <Slider
+      className="max-w-md"
+      defaultValue={0.4}
+      label="Temperature"
+      maxValue={1}
+      minValue={0}
+      step={0.01}
+    />
+  );
+}

--- a/src/app/bundles/ui/heroui/slider/page.tsx
+++ b/src/app/bundles/ui/heroui/slider/page.tsx
@@ -1,0 +1,5 @@
+import { SliderPage } from "./client";
+
+export default function Page() {
+  return <SliderPage />;
+}

--- a/src/app/bundles/ui/heroui/snippet/client.tsx
+++ b/src/app/bundles/ui/heroui/snippet/client.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import {Snippet} from "@heroui/react";
+
+export function SnippetPage() {
+  return <Snippet>npm install heroui</Snippet>;
+}

--- a/src/app/bundles/ui/heroui/snippet/page.tsx
+++ b/src/app/bundles/ui/heroui/snippet/page.tsx
@@ -1,0 +1,5 @@
+import { SnippetPage } from "./client";
+
+export default function Page() {
+  return <SnippetPage />;
+}

--- a/src/app/bundles/ui/heroui/spacer/client.tsx
+++ b/src/app/bundles/ui/heroui/spacer/client.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import {Spacer} from "@heroui/react";
+
+export function SpacerPage() {
+  return (
+    <div>
+      <p>Above</p>
+      <Spacer y={1} />
+      <p>Below</p>
+    </div>
+  );
+}

--- a/src/app/bundles/ui/heroui/spacer/page.tsx
+++ b/src/app/bundles/ui/heroui/spacer/page.tsx
@@ -1,0 +1,5 @@
+import { SpacerPage } from "./client";
+
+export default function Page() {
+  return <SpacerPage />;
+}

--- a/src/app/bundles/ui/heroui/spinner/client.tsx
+++ b/src/app/bundles/ui/heroui/spinner/client.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import {Spinner} from "@heroui/react";
+
+export function SpinnerPage() {
+  return <Spinner />;
+}

--- a/src/app/bundles/ui/heroui/spinner/page.tsx
+++ b/src/app/bundles/ui/heroui/spinner/page.tsx
@@ -1,0 +1,5 @@
+import { SpinnerPage } from "./client";
+
+export default function Page() {
+  return <SpinnerPage />;
+}

--- a/src/app/bundles/ui/heroui/switch/client.tsx
+++ b/src/app/bundles/ui/heroui/switch/client.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import {Switch} from "@heroui/react";
+
+export function SwitchPage() {
+  return <Switch />;
+}

--- a/src/app/bundles/ui/heroui/switch/page.tsx
+++ b/src/app/bundles/ui/heroui/switch/page.tsx
@@ -1,0 +1,5 @@
+import { SwitchPage } from "./client";
+
+export default function Page() {
+  return <SwitchPage />;
+}

--- a/src/app/bundles/ui/heroui/table/client.tsx
+++ b/src/app/bundles/ui/heroui/table/client.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import {Table, TableHeader, TableColumn, TableBody, TableRow, TableCell} from "@heroui/react";
+
+export function TablePage() {
+  return (
+    <Table aria-label="Example static collection table">
+      <TableHeader>
+        <TableColumn>NAME</TableColumn>
+        <TableColumn>ROLE</TableColumn>
+        <TableColumn>STATUS</TableColumn>
+      </TableHeader>
+      <TableBody>
+        <TableRow key="1">
+          <TableCell>Tony Reichert</TableCell>
+          <TableCell>CEO</TableCell>
+          <TableCell>Active</TableCell>
+        </TableRow>
+        <TableRow key="2">
+          <TableCell>Zoey Lang</TableCell>
+          <TableCell>Technical Lead</TableCell>
+          <TableCell>Paused</TableCell>
+        </TableRow>
+        <TableRow key="3">
+          <TableCell>Jane Fisher</TableCell>
+          <TableCell>Senior Developer</TableCell>
+          <TableCell>Active</TableCell>
+        </TableRow>
+        <TableRow key="4">
+          <TableCell>William Howard</TableCell>
+          <TableCell>Community Manager</TableCell>
+          <TableCell>Vacation</TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  );
+}

--- a/src/app/bundles/ui/heroui/table/page.tsx
+++ b/src/app/bundles/ui/heroui/table/page.tsx
@@ -1,0 +1,5 @@
+import { TablePage } from "./client";
+
+export default function Page() {
+  return <TablePage />;
+}

--- a/src/app/bundles/ui/heroui/tabs/client.tsx
+++ b/src/app/bundles/ui/heroui/tabs/client.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import {Tabs, Tab} from "@heroui/react";
+
+export function TabsPage() {
+  return (
+    <div className="flex w-full flex-col">
+      <Tabs aria-label="Options">
+        <Tab key="photos" title="Photos">
+          <div>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+            incididunt ut labore et dolore magna aliqua.
+          </div>
+        </Tab>
+        <Tab key="music" title="Music">
+          <div>
+            Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+            commodo consequat.
+          </div>
+        </Tab>
+        <Tab key="videos" title="Videos">
+          <div>
+            Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+            anim id est laborum.
+          </div>
+        </Tab>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/app/bundles/ui/heroui/tabs/page.tsx
+++ b/src/app/bundles/ui/heroui/tabs/page.tsx
@@ -1,0 +1,5 @@
+import { TabsPage } from "./client";
+
+export default function Page() {
+  return <TabsPage />;
+}

--- a/src/app/bundles/ui/heroui/toast/client.tsx
+++ b/src/app/bundles/ui/heroui/toast/client.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import {addToast} from "@heroui/react";
+
+export function ToastPage() {
+  return (
+    <button
+      onClick={() => {
+        addToast({title: "Toast Title"});
+      }}
+    >
+      Default
+    </button>
+  );
+}

--- a/src/app/bundles/ui/heroui/toast/page.tsx
+++ b/src/app/bundles/ui/heroui/toast/page.tsx
@@ -1,0 +1,10 @@
+import { ToastPage } from "./client";
+import Providers from "./providers";
+
+export default function Page() {
+  return (
+    <Providers>
+      <ToastPage />
+    </Providers>
+  );
+}

--- a/src/app/bundles/ui/heroui/toast/providers.tsx
+++ b/src/app/bundles/ui/heroui/toast/providers.tsx
@@ -1,0 +1,12 @@
+"use client";
+import {HeroUIProvider} from "@heroui/react";
+import {ToastProvider} from "@heroui/toast";
+
+export default function Providers({children}: {children: React.ReactNode}) {
+  return (
+    <HeroUIProvider>
+      <ToastProvider />
+      {children}
+    </HeroUIProvider>
+  );
+}

--- a/src/app/bundles/ui/heroui/tooltip/client.tsx
+++ b/src/app/bundles/ui/heroui/tooltip/client.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import {Tooltip} from "@heroui/react";
+
+export function TooltipPage() {
+  return (
+    <Tooltip content="I am a tooltip">
+      <button>Hover me</button>
+    </Tooltip>
+  );
+}

--- a/src/app/bundles/ui/heroui/tooltip/page.tsx
+++ b/src/app/bundles/ui/heroui/tooltip/page.tsx
@@ -1,0 +1,5 @@
+import { TooltipPage } from "./client";
+
+export default function Page() {
+  return <TooltipPage />;
+}

--- a/src/app/bundles/ui/heroui/user/client.tsx
+++ b/src/app/bundles/ui/heroui/user/client.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import {User} from "@heroui/react";
+
+export function UserPage() {
+  return (
+    <User
+      avatarProps={{
+        src: "https://i.pravatar.cc/150?u=a04258114e29026702d",
+      }}
+      description="Product Designer"
+      name="Jane Doe"
+    />
+  );
+}

--- a/src/app/bundles/ui/heroui/user/page.tsx
+++ b/src/app/bundles/ui/heroui/user/page.tsx
@@ -1,0 +1,5 @@
+import { UserPage } from "./client";
+
+export default function Page() {
+  return <UserPage />;
+}

--- a/src/app/ui/heroui/[...any]/page.tsx
+++ b/src/app/ui/heroui/[...any]/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "../page";

--- a/src/app/ui/heroui/page.tsx
+++ b/src/app/ui/heroui/page.tsx
@@ -1,0 +1,10 @@
+import { ImpactTable } from "@/components/impact-table";
+
+export default async function Page() {
+  return (
+    <div className="max-w-2xl mx-auto my-8">
+      <h1 className="text-2xl font-semibold mb-4">Hero UI</h1>
+      <ImpactTable routePattern="/bundles/ui/heroui/:name" trimPrefix={["/bundles/ui/heroui/"]} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- flesh out Hero UI demo pages with actual component examples
- wrap toast example with HeroUIProvider and ToastProvider
- use plain anchors and buttons in the Navbar example

## Testing
- `npx next lint`
- `pnpm build` *(fails: Failed to fetch fonts)*