### PR TITLE
Add Headless UI examples

### DIFF
--- a/src/app/bundles/ui/headlessui/button/client.tsx
+++ b/src/app/bundles/ui/headlessui/button/client.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import { Button } from '@headlessui/react'
+
+export function ButtonPage() {
+  return (
+    <Button className="rounded bg-sky-600 px-4 py-2 text-sm text-white data-active:bg-sky-700 data-hover:bg-sky-500">Save changes</Button>
+  )
+}

--- a/src/app/bundles/ui/headlessui/button/page.tsx
+++ b/src/app/bundles/ui/headlessui/button/page.tsx
@@ -1,0 +1,4 @@
+import { ButtonPage } from './client'
+export default function Page() {
+  return <ButtonPage />
+}

--- a/src/app/bundles/ui/headlessui/checkbox/client.tsx
+++ b/src/app/bundles/ui/headlessui/checkbox/client.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { Checkbox } from '@headlessui/react'
+import { useState } from 'react'
+
+export function CheckboxPage() {
+  const [enabled, setEnabled] = useState(false)
+
+  return (
+    <Checkbox checked={enabled} onChange={setEnabled} className="group block size-4 rounded border bg-white data-checked:bg-blue-500">
+      <svg className="stroke-white opacity-0 group-data-checked:opacity-100" viewBox="0 0 14 14" fill="none">
+        <path d="M3 8L6 11L11 3.5" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    </Checkbox>
+  )
+}

--- a/src/app/bundles/ui/headlessui/checkbox/page.tsx
+++ b/src/app/bundles/ui/headlessui/checkbox/page.tsx
@@ -1,0 +1,4 @@
+import { CheckboxPage } from './client'
+export default function Page() {
+  return <CheckboxPage />
+}

--- a/src/app/bundles/ui/headlessui/combobox/client.tsx
+++ b/src/app/bundles/ui/headlessui/combobox/client.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { Combobox, ComboboxInput, ComboboxOption, ComboboxOptions } from '@headlessui/react'
+import { useState } from 'react'
+
+const people = [
+  { id: 1, name: 'Durward Reynolds' },
+  { id: 2, name: 'Kenton Towne' },
+  { id: 3, name: 'Therese Wunsch' },
+  { id: 4, name: 'Benedict Kessler' },
+  { id: 5, name: 'Katelyn Rohan' }
+]
+
+export function ComboboxPage() {
+  const [selectedPerson, setSelectedPerson] = useState(people[0])
+  const [query, setQuery] = useState('')
+
+  const filteredPeople =
+    query === ''
+      ? people
+      : people.filter((person) => {
+          return person.name.toLowerCase().includes(query.toLowerCase())
+        })
+
+  return (
+    <Combobox value={selectedPerson} onChange={setSelectedPerson} onClose={() => setQuery('')}>
+      <ComboboxInput aria-label="Assignee" displayValue={(person) => person?.name} onChange={(event) => setQuery(event.target.value)} />
+      <ComboboxOptions anchor="bottom" className="border empty:invisible">
+        {filteredPeople.map((person) => (
+          <ComboboxOption key={person.id} value={person} className="data-focus:bg-blue-100">
+            {person.name}
+          </ComboboxOption>
+        ))}
+      </ComboboxOptions>
+    </Combobox>
+  )
+}

--- a/src/app/bundles/ui/headlessui/combobox/page.tsx
+++ b/src/app/bundles/ui/headlessui/combobox/page.tsx
@@ -1,0 +1,4 @@
+import { ComboboxPage } from './client'
+export default function Page() {
+  return <ComboboxPage />
+}

--- a/src/app/bundles/ui/headlessui/dialog/client.tsx
+++ b/src/app/bundles/ui/headlessui/dialog/client.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { Description, Dialog, DialogPanel, DialogTitle } from '@headlessui/react'
+import { useState } from 'react'
+
+export function DialogPage() {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <>
+      <button onClick={() => setIsOpen(true)}>Open dialog</button>
+      <Dialog open={isOpen} onClose={() => setIsOpen(false)} className="relative z-50">
+        <div className="fixed inset-0 flex w-screen items-center justify-center p-4">
+          <DialogPanel className="max-w-lg space-y-4 border bg-white p-12">
+            <DialogTitle className="font-bold">Deactivate account</DialogTitle>
+            <Description>This will permanently deactivate your account</Description>
+            <p>Are you sure you want to deactivate your account? All of your data will be permanently removed.</p>
+            <div className="flex gap-4">
+              <button onClick={() => setIsOpen(false)}>Cancel</button>
+              <button onClick={() => setIsOpen(false)}>Deactivate</button>
+            </div>
+          </DialogPanel>
+        </div>
+      </Dialog>
+    </>
+  )
+}

--- a/src/app/bundles/ui/headlessui/dialog/page.tsx
+++ b/src/app/bundles/ui/headlessui/dialog/page.tsx
@@ -1,0 +1,4 @@
+import { DialogPage } from './client'
+export default function Page() {
+  return <DialogPage />
+}

--- a/src/app/bundles/ui/headlessui/disclosure/client.tsx
+++ b/src/app/bundles/ui/headlessui/disclosure/client.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/react'
+
+export function DisclosurePage() {
+  return (
+    <Disclosure>
+      <DisclosureButton className="py-2">Is team pricing available?</DisclosureButton>
+      <DisclosurePanel className="text-gray-500">Yes! You can purchase a license that you can share with your entire team.</DisclosurePanel>
+    </Disclosure>
+  )
+}

--- a/src/app/bundles/ui/headlessui/disclosure/page.tsx
+++ b/src/app/bundles/ui/headlessui/disclosure/page.tsx
@@ -1,0 +1,4 @@
+import { DisclosurePage } from './client'
+export default function Page() {
+  return <DisclosurePage />
+}

--- a/src/app/bundles/ui/headlessui/dropdown-menu/client.tsx
+++ b/src/app/bundles/ui/headlessui/dropdown-menu/client.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react'
+
+export function DropdownMenuPage() {
+  return (
+    <Menu>
+      <MenuButton>My account</MenuButton>
+      <MenuItems anchor="bottom">
+        <MenuItem>
+          <a className="block data-focus:bg-blue-100" href="/settings">
+            Settings
+          </a>
+        </MenuItem>
+        <MenuItem>
+          <a className="block data-focus:bg-blue-100" href="/support">
+            Support
+          </a>
+        </MenuItem>
+        <MenuItem>
+          <a className="block data-focus:bg-blue-100" href="/license">
+            License
+          </a>
+        </MenuItem>
+      </MenuItems>
+    </Menu>
+  )
+}

--- a/src/app/bundles/ui/headlessui/dropdown-menu/page.tsx
+++ b/src/app/bundles/ui/headlessui/dropdown-menu/page.tsx
@@ -1,0 +1,4 @@
+import { DropdownMenuPage } from './client'
+export default function Page() {
+  return <DropdownMenuPage />
+}

--- a/src/app/bundles/ui/headlessui/fieldset/client.tsx
+++ b/src/app/bundles/ui/headlessui/fieldset/client.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { Field, Fieldset, Input, Label, Legend, Select, Textarea } from '@headlessui/react'
+
+export function FieldsetPage() {
+  return (
+    <Fieldset className="space-y-8">
+      <Legend className="text-lg font-bold">Shipping details</Legend>
+      <Field>
+        <Label className="block">Street address</Label>
+        <Input className="mt-1 block" name="address" />
+      </Field>
+      <Field>
+        <Label className="block">Country</Label>
+        <Select className="mt-1 block" name="country">
+          <option>Canada</option>
+          <option>Mexico</option>
+          <option>United States</option>
+        </Select>
+      </Field>
+      <Field>
+        <Label className="block">Delivery notes</Label>
+        <Textarea className="mt-1 block" name="notes" />
+      </Field>
+    </Fieldset>
+  )
+}

--- a/src/app/bundles/ui/headlessui/fieldset/page.tsx
+++ b/src/app/bundles/ui/headlessui/fieldset/page.tsx
@@ -1,0 +1,4 @@
+import { FieldsetPage } from './client'
+export default function Page() {
+  return <FieldsetPage />
+}

--- a/src/app/bundles/ui/headlessui/input/client.tsx
+++ b/src/app/bundles/ui/headlessui/input/client.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { Input } from '@headlessui/react'
+
+export function InputPage() {
+  return <Input name="full_name" type="text" />
+}

--- a/src/app/bundles/ui/headlessui/input/page.tsx
+++ b/src/app/bundles/ui/headlessui/input/page.tsx
@@ -1,0 +1,4 @@
+import { InputPage } from './client'
+export default function Page() {
+  return <InputPage />
+}

--- a/src/app/bundles/ui/headlessui/listbox/client.tsx
+++ b/src/app/bundles/ui/headlessui/listbox/client.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { Listbox, ListboxButton, ListboxOption, ListboxOptions } from '@headlessui/react'
+import { useState } from 'react'
+
+const people = [
+  { id: 1, name: 'Durward Reynolds' },
+  { id: 2, name: 'Kenton Towne' },
+  { id: 3, name: 'Therese Wunsch' },
+  { id: 4, name: 'Benedict Kessler' },
+  { id: 5, name: 'Katelyn Rohan' }
+]
+
+export function ListboxPage() {
+  const [selectedPerson, setSelectedPerson] = useState(people[0])
+
+  return (
+    <Listbox value={selectedPerson} onChange={setSelectedPerson}>
+      <ListboxButton>{selectedPerson.name}</ListboxButton>
+      <ListboxOptions anchor="bottom" className="border">
+        {people.map((person) => (
+          <ListboxOption key={person.id} value={person} className="data-focus:bg-blue-100">
+            {person.name}
+          </ListboxOption>
+        ))}
+      </ListboxOptions>
+    </Listbox>
+  )
+}

--- a/src/app/bundles/ui/headlessui/listbox/page.tsx
+++ b/src/app/bundles/ui/headlessui/listbox/page.tsx
@@ -1,0 +1,4 @@
+import { ListboxPage } from './client'
+export default function Page() {
+  return <ListboxPage />
+}

--- a/src/app/bundles/ui/headlessui/popover/client.tsx
+++ b/src/app/bundles/ui/headlessui/popover/client.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import { Popover, PopoverButton, PopoverPanel } from '@headlessui/react'
+
+export function PopoverPage() {
+  return (
+    <Popover className="relative">
+      <PopoverButton>Solutions</PopoverButton>
+      <PopoverPanel anchor="bottom" className="flex flex-col">
+        <a href="/analytics">Analytics</a>
+        <a href="/engagement">Engagement</a>
+        <a href="/security">Security</a>
+        <a href="/integrations">Integrations</a>
+      </PopoverPanel>
+    </Popover>
+  )
+}

--- a/src/app/bundles/ui/headlessui/popover/page.tsx
+++ b/src/app/bundles/ui/headlessui/popover/page.tsx
@@ -1,0 +1,4 @@
+import { PopoverPage } from './client'
+export default function Page() {
+  return <PopoverPage />
+}

--- a/src/app/bundles/ui/headlessui/radio-group/client.tsx
+++ b/src/app/bundles/ui/headlessui/radio-group/client.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { RadioGroup, Radio } from '@headlessui/react'
+import { useState } from 'react'
+
+export function RadioGroupPage() {
+  const [selected, setSelected] = useState('startup')
+
+  return (
+    <RadioGroup value={selected} onChange={setSelected}>
+      <Radio value="startup">Startup</Radio>
+      <Radio value="enterprise">Enterprise</Radio>
+    </RadioGroup>
+  )
+}

--- a/src/app/bundles/ui/headlessui/radio-group/page.tsx
+++ b/src/app/bundles/ui/headlessui/radio-group/page.tsx
@@ -1,0 +1,4 @@
+import { RadioGroupPage } from './client'
+export default function Page() {
+  return <RadioGroupPage />
+}

--- a/src/app/bundles/ui/headlessui/select/client.tsx
+++ b/src/app/bundles/ui/headlessui/select/client.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { Select } from '@headlessui/react'
+
+export function SelectPage() {
+  return (
+    <Select name="status" aria-label="Project status">
+      <option value="active">Active</option>
+      <option value="paused">Paused</option>
+      <option value="delayed">Delayed</option>
+      <option value="canceled">Canceled</option>
+    </Select>
+  )
+}

--- a/src/app/bundles/ui/headlessui/select/page.tsx
+++ b/src/app/bundles/ui/headlessui/select/page.tsx
@@ -1,0 +1,4 @@
+import { SelectPage } from './client'
+export default function Page() {
+  return <SelectPage />
+}

--- a/src/app/bundles/ui/headlessui/switch/client.tsx
+++ b/src/app/bundles/ui/headlessui/switch/client.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import { Switch } from '@headlessui/react'
+import { useState } from 'react'
+
+export function SwitchPage() {
+  const [enabled, setEnabled] = useState(false)
+
+  return (
+    <Switch
+      checked={enabled}
+      onChange={setEnabled}
+      className="group inline-flex h-6 w-11 items-center rounded-full bg-gray-200 transition data-checked:bg-blue-600"
+    >
+      <span className="size-4 translate-x-1 rounded-full bg-white transition group-data-checked:translate-x-6" />
+    </Switch>
+  )
+}

--- a/src/app/bundles/ui/headlessui/switch/page.tsx
+++ b/src/app/bundles/ui/headlessui/switch/page.tsx
@@ -1,0 +1,4 @@
+import { SwitchPage } from './client'
+export default function Page() {
+  return <SwitchPage />
+}

--- a/src/app/bundles/ui/headlessui/tabs/client.tsx
+++ b/src/app/bundles/ui/headlessui/tabs/client.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@headlessui/react'
+
+export function TabsPage() {
+  return (
+    <TabGroup>
+      <TabList>
+        <Tab>Tab 1</Tab>
+        <Tab>Tab 2</Tab>
+        <Tab>Tab 3</Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel>Content 1</TabPanel>
+        <TabPanel>Content 2</TabPanel>
+        <TabPanel>Content 3</TabPanel>
+      </TabPanels>
+    </TabGroup>
+  )
+}

--- a/src/app/bundles/ui/headlessui/tabs/page.tsx
+++ b/src/app/bundles/ui/headlessui/tabs/page.tsx
@@ -1,0 +1,4 @@
+import { TabsPage } from './client'
+export default function Page() {
+  return <TabsPage />
+}

--- a/src/app/bundles/ui/headlessui/textarea/client.tsx
+++ b/src/app/bundles/ui/headlessui/textarea/client.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { Textarea } from '@headlessui/react'
+
+export function TextareaPage() {
+  return <Textarea name="description"></Textarea>
+}

--- a/src/app/bundles/ui/headlessui/textarea/page.tsx
+++ b/src/app/bundles/ui/headlessui/textarea/page.tsx
@@ -1,0 +1,4 @@
+import { TextareaPage } from './client'
+export default function Page() {
+  return <TextareaPage />
+}

--- a/src/app/bundles/ui/headlessui/transition/client.tsx
+++ b/src/app/bundles/ui/headlessui/transition/client.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import { Transition } from '@headlessui/react'
+import { useState } from 'react'
+
+export function TransitionPage() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <button onClick={() => setOpen((open) => !open)}>Toggle</button>
+      <Transition show={open}>
+        <div className="transition duration-300 ease-in data-closed:opacity-0">I will fade in and out</div>
+      </Transition>
+    </>
+  )
+}

--- a/src/app/bundles/ui/headlessui/transition/page.tsx
+++ b/src/app/bundles/ui/headlessui/transition/page.tsx
@@ -1,0 +1,4 @@
+import { TransitionPage } from './client'
+export default function Page() {
+  return <TransitionPage />
+}

--- a/src/app/ui/headlessui/[...any]/page.tsx
+++ b/src/app/ui/headlessui/[...any]/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../page'

--- a/src/app/ui/headlessui/page.tsx
+++ b/src/app/ui/headlessui/page.tsx
@@ -1,0 +1,10 @@
+import { ImpactTable } from '@/components/impact-table'
+
+export default async function Page() {
+  return (
+    <div className="mx-auto my-8 max-w-2xl">
+      <h1 className="mb-4 text-2xl font-semibold">Headless UI</h1>
+      <ImpactTable routePattern="/bundles/ui/headlessui/:name" trimPrefix={['/bundles/ui/headlessui/']} />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `headlessui` pages with ImpactTable
- include example components for all Headless UI widgets

## Testing
- `pnpm lint`
- `pnpm build` *(fails: connect EHOSTUNREACH)*