### PR TITLE
Add native button and select examples

### DIFF
--- a/src/app/bundles/native/button/client.tsx
+++ b/src/app/bundles/native/button/client.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+export function ButtonPage() {
+  return (
+    <button className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700">
+      Click me
+    </button>
+  )
+}

--- a/src/app/bundles/native/button/page.tsx
+++ b/src/app/bundles/native/button/page.tsx
@@ -1,0 +1,5 @@
+import { ButtonPage } from './client'
+
+export default function Page() {
+  return <ButtonPage />
+}

--- a/src/app/bundles/native/input/client.tsx
+++ b/src/app/bundles/native/input/client.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export function InputPage() {
+  return <input type="text" className="rounded border px-3 py-2" />
+}

--- a/src/app/bundles/native/input/page.tsx
+++ b/src/app/bundles/native/input/page.tsx
@@ -1,0 +1,5 @@
+import { InputPage } from './client'
+
+export default function Page() {
+  return <InputPage />
+}

--- a/src/app/bundles/native/select/client.tsx
+++ b/src/app/bundles/native/select/client.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+export function SelectPage() {
+  return (
+    <select className="rounded border px-3 py-2">
+      <option value="apple">Apple</option>
+      <option value="banana">Banana</option>
+      <option value="orange">Orange</option>
+    </select>
+  )
+}

--- a/src/app/bundles/native/select/page.tsx
+++ b/src/app/bundles/native/select/page.tsx
@@ -1,0 +1,5 @@
+import { SelectPage } from './client'
+
+export default function Page() {
+  return <SelectPage />
+}

--- a/src/app/ui/native/[...any]/page.tsx
+++ b/src/app/ui/native/[...any]/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../page'

--- a/src/app/ui/native/page.tsx
+++ b/src/app/ui/native/page.tsx
@@ -1,0 +1,10 @@
+import { ImpactTable } from '@/components/impact-table'
+
+export default async function Page() {
+  return (
+    <div className="mx-auto my-8 max-w-2xl">
+      <h1 className="mb-4 text-2xl font-semibold">Native</h1>
+      <ImpactTable routePattern="/bundles/native/:name" trimPrefix={['/bundles/native/']} />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add plain React/Tailwind examples for native `button` and `select`

## Testing
- `pnpm lint`
- `pnpm build` *(fails: connect EHOSTUNREACH 172.25.0.3:8080)*
