### PR TITLE
Add more isolated Material UI demos

### DIFF
--- a/src/app/bundles/ui/material/bottom-navigation/client.tsx
+++ b/src/app/bundles/ui/material/bottom-navigation/client.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import BottomNavigation from '@mui/material/BottomNavigation'
+
+export default function BottomNavigationClient() {
+  return (
+    <BottomNavigation>
+      <button>One</button>
+      <button>Two</button>
+    </BottomNavigation>
+  )
+}

--- a/src/app/bundles/ui/material/bottom-navigation/page.tsx
+++ b/src/app/bundles/ui/material/bottom-navigation/page.tsx
@@ -1,0 +1,5 @@
+import BottomNavigationClient from './client'
+
+export default function BottomNavigationPage() {
+  return <BottomNavigationClient />
+}

--- a/src/app/bundles/ui/material/box/client.tsx
+++ b/src/app/bundles/ui/material/box/client.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import Box from '@mui/material/Box'
+
+export default function BoxClient() {
+  return <Box>Box</Box>
+}

--- a/src/app/bundles/ui/material/box/page.tsx
+++ b/src/app/bundles/ui/material/box/page.tsx
@@ -1,0 +1,5 @@
+import BoxClient from './client'
+
+export default function BoxPage() {
+  return <BoxClient />
+}

--- a/src/app/bundles/ui/material/breadcrumbs/client.tsx
+++ b/src/app/bundles/ui/material/breadcrumbs/client.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import Breadcrumbs from '@mui/material/Breadcrumbs'
+
+export default function BreadcrumbsClient() {
+  return (
+    <Breadcrumbs>
+      <a href="#">Home</a>
+      <a href="#">Page</a>
+    </Breadcrumbs>
+  )
+}

--- a/src/app/bundles/ui/material/breadcrumbs/page.tsx
+++ b/src/app/bundles/ui/material/breadcrumbs/page.tsx
@@ -1,0 +1,5 @@
+import BreadcrumbsClient from './client'
+
+export default function BreadcrumbsPage() {
+  return <BreadcrumbsClient />
+}

--- a/src/app/bundles/ui/material/container/client.tsx
+++ b/src/app/bundles/ui/material/container/client.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import Container from '@mui/material/Container'
+
+export default function ContainerClient() {
+  return (
+    <Container>
+      <div />
+    </Container>
+  )
+}

--- a/src/app/bundles/ui/material/container/page.tsx
+++ b/src/app/bundles/ui/material/container/page.tsx
@@ -1,0 +1,5 @@
+import ContainerClient from './client'
+
+export default function ContainerPage() {
+  return <ContainerClient />
+}

--- a/src/app/bundles/ui/material/drawer/client.tsx
+++ b/src/app/bundles/ui/material/drawer/client.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import Drawer from '@mui/material/Drawer'
+import { useState } from 'react'
+
+export default function DrawerClient() {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Open</button>
+      <Drawer open={open} onClose={() => setOpen(false)}>
+        <button onClick={() => setOpen(false)}>Close</button>
+      </Drawer>
+    </>
+  )
+}

--- a/src/app/bundles/ui/material/drawer/page.tsx
+++ b/src/app/bundles/ui/material/drawer/page.tsx
@@ -1,0 +1,5 @@
+import DrawerClient from './client'
+
+export default function DrawerPage() {
+  return <DrawerClient />
+}

--- a/src/app/bundles/ui/material/grid/client.tsx
+++ b/src/app/bundles/ui/material/grid/client.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import Grid from '@mui/material/Grid'
+
+export default function GridClient() {
+  return (
+    <Grid container>
+      <Grid item>
+        <div />
+      </Grid>
+    </Grid>
+  )
+}

--- a/src/app/bundles/ui/material/grid/page.tsx
+++ b/src/app/bundles/ui/material/grid/page.tsx
@@ -1,0 +1,5 @@
+import GridClient from './client'
+
+export default function GridPage() {
+  return <GridClient />
+}

--- a/src/app/bundles/ui/material/image-list/client.tsx
+++ b/src/app/bundles/ui/material/image-list/client.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import ImageList from '@mui/material/ImageList'
+
+export default function ImageListClient() {
+  return (
+    <ImageList>
+      <li>
+        <img src="" alt="" />
+      </li>
+    </ImageList>
+  )
+}

--- a/src/app/bundles/ui/material/image-list/page.tsx
+++ b/src/app/bundles/ui/material/image-list/page.tsx
@@ -1,0 +1,5 @@
+import ImageListClient from './client'
+
+export default function ImageListPage() {
+  return <ImageListClient />
+}

--- a/src/app/bundles/ui/material/link/client.tsx
+++ b/src/app/bundles/ui/material/link/client.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import Link from '@mui/material/Link'
+
+export default function LinkClient() {
+  return <Link href="#">Link</Link>
+}

--- a/src/app/bundles/ui/material/link/page.tsx
+++ b/src/app/bundles/ui/material/link/page.tsx
@@ -1,0 +1,5 @@
+import LinkClient from './client'
+
+export default function LinkPage() {
+  return <LinkClient />
+}

--- a/src/app/bundles/ui/material/menu/client.tsx
+++ b/src/app/bundles/ui/material/menu/client.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import Menu from '@mui/material/Menu'
+import { useState } from 'react'
+
+export default function MenuClient() {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
+  return (
+    <>
+      <button onClick={(e) => setAnchorEl(e.currentTarget)}>Open menu</button>
+      <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={() => setAnchorEl(null)}>
+        <button onClick={() => setAnchorEl(null)}>Item</button>
+      </Menu>
+    </>
+  )
+}

--- a/src/app/bundles/ui/material/menu/page.tsx
+++ b/src/app/bundles/ui/material/menu/page.tsx
@@ -1,0 +1,5 @@
+import MenuClient from './client'
+
+export default function MenuPage() {
+  return <MenuClient />
+}

--- a/src/app/bundles/ui/material/pagination/client.tsx
+++ b/src/app/bundles/ui/material/pagination/client.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import Pagination from '@mui/material/Pagination'
+
+export default function PaginationClient() {
+  return <Pagination count={10} page={1} />
+}

--- a/src/app/bundles/ui/material/pagination/page.tsx
+++ b/src/app/bundles/ui/material/pagination/page.tsx
@@ -1,0 +1,5 @@
+import PaginationClient from './client'
+
+export default function PaginationPage() {
+  return <PaginationClient />
+}

--- a/src/app/bundles/ui/material/speed-dial/client.tsx
+++ b/src/app/bundles/ui/material/speed-dial/client.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import SpeedDial from '@mui/material/SpeedDial'
+
+export default function SpeedDialClient() {
+  return <SpeedDial ariaLabel="speed dial" icon={<span>+</span>} />
+}

--- a/src/app/bundles/ui/material/speed-dial/page.tsx
+++ b/src/app/bundles/ui/material/speed-dial/page.tsx
@@ -1,0 +1,5 @@
+import SpeedDialClient from './client'
+
+export default function SpeedDialPage() {
+  return <SpeedDialClient />
+}

--- a/src/app/bundles/ui/material/stack/client.tsx
+++ b/src/app/bundles/ui/material/stack/client.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import Stack from '@mui/material/Stack'
+
+export default function StackClient() {
+  return (
+    <Stack>
+      <div>One</div>
+      <div>Two</div>
+    </Stack>
+  )
+}

--- a/src/app/bundles/ui/material/stack/page.tsx
+++ b/src/app/bundles/ui/material/stack/page.tsx
@@ -1,0 +1,5 @@
+import StackClient from './client'
+
+export default function StackPage() {
+  return <StackClient />
+}

--- a/src/app/bundles/ui/material/stepper/client.tsx
+++ b/src/app/bundles/ui/material/stepper/client.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import Stepper from '@mui/material/Stepper'
+import Step from '@mui/material/Step'
+import StepLabel from '@mui/material/StepLabel'
+
+export default function StepperClient() {
+  return (
+    <Stepper>
+      <Step>
+        <StepLabel>One</StepLabel>
+      </Step>
+    </Stepper>
+  )
+}

--- a/src/app/bundles/ui/material/stepper/page.tsx
+++ b/src/app/bundles/ui/material/stepper/page.tsx
@@ -1,0 +1,5 @@
+import StepperClient from './client'
+
+export default function StepperPage() {
+  return <StepperClient />
+}

--- a/src/app/bundles/ui/material/tabs/client.tsx
+++ b/src/app/bundles/ui/material/tabs/client.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import Tabs from '@mui/material/Tabs'
+import Tab from '@mui/material/Tab'
+
+export default function TabsClient() {
+  return (
+    <Tabs value={0}>
+      <Tab label="Tab" />
+    </Tabs>
+  )
+}

--- a/src/app/bundles/ui/material/tabs/page.tsx
+++ b/src/app/bundles/ui/material/tabs/page.tsx
@@ -1,0 +1,5 @@
+import TabsClient from './client'
+
+export default function TabsPage() {
+  return <TabsClient />
+}


### PR DESCRIPTION
## Summary
- add pages for Material-UI components: BottomNavigation, Breadcrumbs, Drawer, Link, Menu, Pagination, SpeedDial, Stepper, Tabs, Box, Container, Grid, Stack, ImageList

## Testing
- `pnpm lint`
