### PR TITLE
Add endpoint for fetching a component across UI kits

### DIFF
--- a/src/app/api/component/route.ts
+++ b/src/app/api/component/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server'
+import { getSearchIndex } from '@/lib/search-index'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const name = (searchParams.get('component') || '').toLowerCase().trim()
+  const exact = searchParams.get('exactMatch')
+  const exactMatch = exact === 'true' || exact === '1'
+
+  if (!name) {
+    return NextResponse.json([])
+  }
+
+  const index = await getSearchIndex()
+  const filtered = index.filter(
+    (entry) => entry.type === 'ui' && (exactMatch ? entry.path[1].toLowerCase() === name : entry.path[1].toLowerCase().includes(name))
+  )
+
+  return NextResponse.json(filtered)
+}


### PR DESCRIPTION
## Summary
- add `/api/component` endpoint to query for a given component across all ui libraries

## Testing
- `pnpm lint`
- `pnpm prettier`

------
https://chatgpt.com/codex/tasks/task_e_6839df53b10483219a33029cb9f954b0