### PR TITLE
Support multi-component exact search

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,13 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## API
+
+### `/api/component`
+
+Returns build information about UI components. Specify one or more `component` query parameters or a comma‑separated list of names. When `exactMatch` is set to `true` or `1`, results will only include components whose names exactly match any provided value.
+
+```text
+/api/component?component=dialog,modal&exactMatch=true
+```


### PR DESCRIPTION
## Summary
- allow passing multiple `component` parameters and comma-separated values to `/api/component`
- document the new API usage in README

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68756003655c83218adb7887372c3ad2